### PR TITLE
feat: add custom CSS support with userstyles folder and live reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ npm run start
 # Or package release builds
 npm run build
 ```
+
+## Custom CSS (Userstyles)
+
+You can apply custom styles to VacuumTube by first enabling it in the settings, and then creating `.css` files in the userstyles folder.
+
+### File Location
+
+Your userstyles folder is located at:
+
+- **Windows**: `%APPDATA%\VacuumTube\userstyles\`
+- **Linux**: `~/.config/VacuumTube/userstyles/`

--- a/config.js
+++ b/config.js
@@ -15,7 +15,8 @@ const defaults = {
     hardware_decoding: true, //use hardware gpu video decoding
     h264ify: false, //block non-h264 codecs for performance on slow devices
     low_memory_mode: false, //enables env_isLimitedMemory
-    keep_on_top: false //whether or not to keep window on top
+    keep_on_top: false, //whether or not to keep window on top
+    userstyles: false //whether or not to enable custom CSS injection
 }
 
 function init(overrides = {}) {

--- a/locale/en.json
+++ b/locale/en.json
@@ -26,6 +26,10 @@
         "keep_on_top": {
             "title": "Keep on Top",
             "description": "Enables Keep on Top, and makes VacuumTube launch with the window pinned on top of every other window."
+        },
+        "userstyles": {
+            "title": "Custom CSS (Userstyles)",
+            "description": "Enables injection of custom CSS styles. Place your .css files in the userstyles folder."
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.3.6",
             "license": "MIT",
             "dependencies": {
+                "chokidar": "^4.0.3",
                 "electron-updater": "^6.6.2"
             },
             "devDependencies": {
@@ -1524,6 +1525,21 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/chownr": {
@@ -4422,6 +4438,19 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "electron-builder": "^25.1.8"
     },
     "dependencies": {
-        "electron-updater": "^6.6.2"
+        "electron-updater": "^6.6.2",
+        "chokidar": "^4.0.3"
     }
 }

--- a/preload/modules/settings.js
+++ b/preload/modules/settings.js
@@ -77,6 +77,11 @@ module.exports = async () => {
             locale.settings.keep_on_top.description,
             'keep_on_top',
             (value) => ipcRenderer.invoke('set-on-top', value)
+        ),
+        'userstyles': createSettingBooleanRenderer(
+            locale.settings.userstyles.title,
+            locale.settings.userstyles.description,
+            'userstyles'
         )
     }
 
@@ -88,7 +93,7 @@ module.exports = async () => {
             config = configManager.get()
 
             for (let key of Object.keys(configOptions)) {
-                configOptions[key].settingBooleanRenderer.enabled = config[key] //it's actually reference based, you have to change the object itself when changing config for it to update (this took SO long to figure out, then it clicked...)
+                    configOptions[key].settingBooleanRenderer.enabled = config[key] //it's actually reference based, you have to change the object itself when changing config for it to update (this took SO long to figure out, then it clicked...)
             }
 
             if (input.dynamicFunction) {

--- a/preload/modules/userstyles.js
+++ b/preload/modules/userstyles.js
@@ -1,0 +1,85 @@
+//custom CSS styles
+
+const { ipcRenderer } = require("electron");
+const configManager = require("../config");
+
+let config = configManager.get();
+let injectedStyles = new Set();
+
+function injectCSS(filename, css) {
+  const styleId = `userstyle-${filename.replace(/[^a-zA-Z0-9]/g, "-")}`;
+
+  const existingStyle = document.getElementById(styleId);
+  if (existingStyle) {
+    existingStyle.remove();
+  }
+
+  const style = document.createElement("style");
+  style.id = styleId;
+  style.type = "text/css";
+  style.textContent = css;
+  document.head.appendChild(style);
+
+  injectedStyles.add(filename);
+  console.log(`[Userstyles] Injected: ${filename}`);
+}
+
+function removeCSS(filename) {
+  const styleId = `userstyle-${filename.replace(/[^a-zA-Z0-9]/g, "-")}`;
+  const style = document.getElementById(styleId);
+  if (style) {
+    style.remove();
+    injectedStyles.delete(filename);
+    console.log(`[Userstyles] Removed: ${filename}`);
+  }
+}
+
+async function loadUserstyles() {
+  if (!config.userstyles) {
+    console.log("[Userstyles] Disabled in config");
+    return;
+  }
+
+  try {
+    const styles = await ipcRenderer.invoke("get-userstyles");
+
+    injectedStyles.forEach((filename) => removeCSS(filename));
+
+    styles.forEach(({ filename, css }) => {
+      injectCSS(filename, css);
+    });
+
+    console.log(`[Userstyles] Loaded ${styles.length} stylesheets`);
+  } catch (error) {
+    console.error("[Userstyles] Failed to load styles:", error);
+  }
+}
+
+module.exports = async () => {
+  console.log("[Userstyles] Initializing...");
+
+  await loadUserstyles();
+
+  ipcRenderer.on("config-update", (event, newConfig) => {
+    const wasEnabled = config.userstyles;
+    config = newConfig;
+
+    if (config.userstyles && !wasEnabled) {
+      loadUserstyles();
+    } else if (!config.userstyles && wasEnabled) {
+      injectedStyles.forEach((filename) => removeCSS(filename));
+    }
+  });
+
+  ipcRenderer.on("userstyle-updated", (event, { filename, css }) => {
+    if (config.userstyles) {
+      injectCSS(filename, css);
+    }
+  });
+
+  ipcRenderer.on("userstyle-removed", (event, { filename }) => {
+    removeCSS(filename);
+  });
+
+  console.log("[Userstyles] Initialized");
+};


### PR DESCRIPTION
Thought I'd give solving #36 myself a go. Wanted to follow the specifications you mentioned in the thread there, hope I did a decent job at that.

[Screencast from 2025-07-12 21-18-29.webm](https://github.com/user-attachments/assets/c9c9841f-2207-4c4d-8bd7-9b295bcb014e)

- config option for toggling userstyles on and off.
- userstyles directory (Windows: `%APPDATA%\VacuumTube\userstyles\`, Linux: `~/.config/VacuumTube/userstyles/`)
- hot reload on file change
- Modified CSP by partially exposing your commented code and making some userstyle specific modifications

---

Small side note because I don't believe this is related to this PR but I have to launch with `--no-sandbox` on Linux, otherwise I get the dreaded `The SUID sandbox helper binary was found, but is not configured correctly.` error.