### PR TITLE
patch: allow external stylesheets and fonts in CSP

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,16 +65,25 @@ async function main() {
                 let header = details.responseHeaders['content-security-policy'][i]
 
                 if (config.userstyles) {
-                    // Allow unsafe-inline and data URLs for style-src to enable userstyles
+                    // Allow unsafe-inline, data URLs, and external stylesheets for userstyles
                     // Remove nonces since unsafe-inline is ignored when nonces are present
                     let styleSrcPattern = /style-src\s([^;]*)/
                     let styleSrcMatch = header.match(styleSrcPattern)
                     if (styleSrcMatch) {
                         let existing = styleSrcMatch[1]
-                        // Remove all nonce values and add unsafe-inline and data:
+                        // Remove all nonce values and add unsafe-inline, data URLs, and wildcard for @import
                         let withoutNonces = existing.replace(/'nonce-[^']*'/g, '').trim()
-                        let updated = `style-src ${withoutNonces} 'unsafe-inline' data:`
+                        let updated = `style-src ${withoutNonces} 'unsafe-inline' data: *`
                         header = header.replace(styleSrcPattern, updated)
+                    }
+
+                    // Allow external fonts
+                    let fontSrcPattern = /font-src\s([^;]*)/
+                    let fontSrcMatch = header.match(fontSrcPattern)
+                    if (fontSrcMatch) {
+                        let existing = fontSrcMatch[1]
+                        let updated = `font-src ${existing} * data:`
+                        header = header.replace(fontSrcPattern, updated)
                     }
                 }
 


### PR DESCRIPTION
Sorry for another PR so soon, but I realized people may want to import external style sheets and fonts.

Tested by adding CSS which imports an external stylesheet, which in turn contains @font-face rules that link to external sources:

Example:
```css
@import url(https://git.host/user/temp-css-host/raw/branch/main/external-font.css);

html, body, html * , body * {
  font-family: ExternalFont, Roboto, "Noto Sans CJK ZH-HK", "Noto Sans Thai", Arial, Helvetica !important;
}

span.ytp-caption-segment {
  /* Using a system font for captions */
  font-family: "JetBrains Maple Mono Medium", "YouTube Noto", Roboto, Arial, Helvetica, Verdana, "PT Sans Caption", sans-serif !important;
  border-radius: 12px;
  padding: 5px 10px;
  margin: 2px;
  background: rgba(8, 8, 8, 0.5) !important;
}
```

**No CSS:**
<img width="2560" height="1440" alt="electron_2025-07-15_17-29-01" src="https://github.com/user-attachments/assets/54eab4a8-eb5f-4c30-ab53-d0011bd20683" />
<img width="2560" height="1440" alt="electron_2025-07-15_17-31-14" src="https://github.com/user-attachments/assets/ee703710-55d8-4fb3-bedb-78395f06719f" />

External CSS & Font:
<img width="2560" height="1440" alt="electron_2025-07-15_17-28-09" src="https://github.com/user-attachments/assets/2174bf1e-ee5f-441a-87ec-6e1fc5928113" />
<img width="2560" height="1440" alt="electron_2025-07-15_17-30-57" src="https://github.com/user-attachments/assets/4479d50f-5f63-45f2-bb2c-27b16fbe485c" />
