### PR TITLE
Add a settings menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const configManager = require('./config.js')
 const package = require('./package.json')
 const {  Menu, MenuItem } = require("electron/main");
 const { ipcRenderer } = require("electron/renderer");
+const { onClick } = require('./settings_menu/settings_menu.js')
 //code
 /*
 about the user agent:
@@ -411,37 +412,23 @@ async function createWindow() {
     win.webContents.on('page-title-updated', () => {
         win.setTitle('VacuumTube')
     })
+    // Adds the settingsMenu
+    const settingsMenu = new Menu();
 
-const menu = new Menu();
+    // The first submenu needs to be the app menu on macOS
+    if (process.platform === "darwin") {
+        const appMenu = new MenuItem({ role: "appMenu" });
+        settingsMenu.append(appMenu);
+    }
 
-// The first submenu needs to be the app menu on macOS
-if (process.platform === "darwin") {
-  const appMenu = new MenuItem({ role: "appMenu" });
-  menu.append(appMenu);
-}
+    const submenu = Menu.buildFromTemplate([{
+        label: "Settings",
+        click: () => onClick(electron),
+        accelerator: "CommandOrControl+Alt+R",
+    }]);
+    settingsMenu.append(new MenuItem({ label: "Custom Menu", submenu }));
 
-const submenu = Menu.buildFromTemplate([
-  {
-    label: "Open a Dialog",
-    click: () => contextMenu.popup(),
-    accelerator: "CommandOrControl+Alt+R",
-  },
-]);
-const contextMenu = Menu.buildFromTemplate([
-  { role: "copy" },
-  { role: "cut" },
-  { role: "paste" },
-  { role: "selectall" },
-]);
-// ipcRenderer.addListener("vacuum-settings-menu", (_event, params) => {
-//   // only show the context menu if the element is editable
-// //   if (params.) {
-//     contextMenu.popup();
-// //   }
-// });
-menu.append(new MenuItem({ label: "Custom Menu", submenu }));
-
-Menu.setApplicationMenu(menu);
+    Menu.setApplicationMenu(settingsMenu);
 }
 
 electron.app.once('ready', () => {

--- a/index.js
+++ b/index.js
@@ -423,7 +423,13 @@ async function createWindow() {
 
     const submenu = Menu.buildFromTemplate([{
         label: "Settings",
-        click: () => onClick(electron),
+        click: () => {
+            if (onClick(electron,configManager)){
+                config = configManager.get();
+                win.webContents.send("config-update", config);
+                //TODO: Make it work without restarting
+            }
+        },
         accelerator: "CommandOrControl+Alt+R",
     }]);
     settingsMenu.append(new MenuItem({ label: "Custom Menu", submenu }));

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ electron.app.setPath('sessionData', sessionData)
 
 const configManager = require('./config.js')
 const package = require('./package.json')
-
+const {  Menu, MenuItem } = require("electron/main");
+const { ipcRenderer } = require("electron/renderer");
 //code
 /*
 about the user agent:
@@ -366,7 +367,7 @@ async function createWindow() {
         win.setAspectRatio(TARGET_RATIO)
     }
 
-    win.setMenuBarVisibility(false)
+    // win.setMenuBarVisibility(false)
     win.setAutoHideMenuBar(false)
 
     win.on('ready-to-show', () => {
@@ -410,6 +411,37 @@ async function createWindow() {
     win.webContents.on('page-title-updated', () => {
         win.setTitle('VacuumTube')
     })
+
+const menu = new Menu();
+
+// The first submenu needs to be the app menu on macOS
+if (process.platform === "darwin") {
+  const appMenu = new MenuItem({ role: "appMenu" });
+  menu.append(appMenu);
+}
+
+const submenu = Menu.buildFromTemplate([
+  {
+    label: "Open a Dialog",
+    click: () => contextMenu.popup(),
+    accelerator: "CommandOrControl+Alt+R",
+  },
+]);
+const contextMenu = Menu.buildFromTemplate([
+  { role: "copy" },
+  { role: "cut" },
+  { role: "paste" },
+  { role: "selectall" },
+]);
+// ipcRenderer.addListener("vacuum-settings-menu", (_event, params) => {
+//   // only show the context menu if the element is editable
+// //   if (params.) {
+//     contextMenu.popup();
+// //   }
+// });
+menu.append(new MenuItem({ label: "Custom Menu", submenu }));
+
+Menu.setApplicationMenu(menu);
 }
 
 electron.app.once('ready', () => {

--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ electron.app.setPath('sessionData', sessionData)
 const configManager = require('./config.js')
 const package = require('./package.json')
 const {  Menu, MenuItem } = require("electron/main");
-const { ipcRenderer } = require("electron/renderer");
-const { onClick } = require('./settings_menu/settings_menu.js')
+const { onSettingsMenuClicked } = require('./settings_menu/settings_menu.js')
 //code
 /*
 about the user agent:
@@ -424,7 +423,7 @@ async function createWindow() {
     const submenu = Menu.buildFromTemplate([{
         label: "Settings",
         click: () => {
-            if (onClick(electron,configManager)){
+            if (onSettingsMenuClicked(electron,configManager)){
                 config = configManager.get();
                 win.webContents.send("config-update", config);
                 //TODO: Make it work without restarting

--- a/settings_menu/settings_menu.js
+++ b/settings_menu/settings_menu.js
@@ -1,0 +1,20 @@
+import { get } from "../config";
+
+export async function onClick(electron) {
+  let response_button = (
+    await electron.dialog.showMessageBox({
+      message: "Settings",
+      detail: "Details",
+      buttons: makeButtonsForMessageBox(),
+      cancelId: -1,
+    })
+  ).response;
+  if (response_button == -1) return;
+
+  console.log("Settings response button:", response_button);
+}
+
+function makeButtonsForMessageBox() {
+  let config = get();
+  return ["Toggle de-arrowing"];
+}

--- a/settings_menu/settings_menu.js
+++ b/settings_menu/settings_menu.js
@@ -1,20 +1,50 @@
-import { get } from "../config";
+// Array of options to toggle from the config(only booleans)
+const toggleableSettings = {
+  fullscreen: "fullscreen",
+  dearrow: "dearrow",
+  dislikes: "dislikes",
+  low_memory_mode: "low memory mode",
+  userstyles: "user styles",
+};
 
-export async function onClick(electron) {
-  let response_button = (
+
+
+// Returns is configManager updated
+export async function onClick(electron, configManager) {
+  let config = configManager.get();
+  let responseButton = (
     await electron.dialog.showMessageBox({
       message: "Settings",
       detail: "Details",
-      buttons: makeButtonsForMessageBox(),
+      buttons: makeButtonsForMessageBox(configManager),
       cancelId: -1,
     })
   ).response;
-  if (response_button == -1) return;
+  if (responseButton == -1) return false;
 
-  console.log("Settings response button:", response_button);
+  console.log("[settings]Settings response button:", responseButton);
+  let newConfig = {};
+  let key = Object.keys(toggleableSettings)[responseButton];
+  newConfig[key] = !config[key];
+  console.log("[settings]New Config:", newConfig);
+  configManager.update(newConfig);
+  return true;
 }
 
-function makeButtonsForMessageBox() {
-  let config = get();
-  return ["Toggle de-arrowing"];
+// Makes the buttons array:["Enable fullscreen","Enable dislikes"...]
+function makeButtonsForMessageBox(configManager) {
+  let config = configManager.get();
+  let buttons = [];
+  for (const e of Object.keys(toggleableSettings)) {
+    let text = textFromBool(!config[e]) + " " + toggleableSettings[e] + ".";
+    console.log("add:", text);
+    buttons.push(text);
+  }
+  console.log("buttons:", buttons);
+  return buttons;
+}
+
+// "Enable" or "Disable"
+function textFromBool(b) {
+  return b ? "Enable" : "Disable";
 }

--- a/settings_menu/settings_menu.js
+++ b/settings_menu/settings_menu.js
@@ -7,16 +7,14 @@ const toggleableSettings = {
   userstyles: "user styles",
 };
 
-
-
 // Returns is configManager updated
-export async function onClick(electron, configManager) {
+export async function onSettingsMenuClicked(electron, configManager) {
   let config = configManager.get();
   let responseButton = (
     await electron.dialog.showMessageBox({
       message: "Settings",
-      detail: "Details",
-      buttons: makeButtonsForMessageBox(configManager),
+      detail: makeDetailsForMessageBox(config),
+      buttons: makeButtonsForMessageBox(config),
       cancelId: -1,
     })
   ).response;
@@ -32,16 +30,25 @@ export async function onClick(electron, configManager) {
 }
 
 // Makes the buttons array:["Enable fullscreen","Enable dislikes"...]
-function makeButtonsForMessageBox(configManager) {
-  let config = configManager.get();
+function makeButtonsForMessageBox(config) {
   let buttons = [];
   for (const e of Object.keys(toggleableSettings)) {
     let text = textFromBool(!config[e]) + " " + toggleableSettings[e] + ".";
-    console.log("add:", text);
     buttons.push(text);
   }
-  console.log("buttons:", buttons);
+  console.log("[settings]buttons:", buttons);
   return buttons;
+}
+
+// Makes the details array:"Enabled fullscreen.\nEnabled dislikes.\n..."
+function makeDetailsForMessageBox(config) {
+  let details = [];
+  for (const e of Object.keys(toggleableSettings)) {
+    let text = textFromBool(config[e]) + "d " + toggleableSettings[e] + ".";
+    details.push(text);
+  }
+  console.log("[settings]details:", details);
+  return details.join("\n");
 }
 
 // "Enable" or "Disable"


### PR DESCRIPTION
The pull request adds a "settings" menu.
It's a hacky solution(under the hood it uses [dialog.showMessageBox](https://www.electronjs.org/docs/latest/api/dialog#dialogshowmessageboxwindow-options).
When you update the settings, you need to restart VacuumTube to work.
Image:
<img width="1158" height="319" alt="image" src="https://github.com/user-attachments/assets/f95dc3b5-764f-42aa-bbb3-0d4323bce6d8" />


TODO:
- [ ] Settings don't require restart to work.