### PR TITLE
don't setAspectRatio on MacOS as it interferes with fullscreen #91

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,6 +344,7 @@ async function createWindow() {
 
     const TARGET_RATIO = 16 / 9;
     const isWindows = process.platform === 'win32'
+    const isMac = process.platform === 'darwin'
 
     if (isWindows) {
         // Custom resize handling for Windows where OS chrome breaks outer-ratio locking.
@@ -365,8 +366,8 @@ async function createWindow() {
             width: outerW,
             height: Math.round((outerW - extraWidth) / TARGET_RATIO) + extraHeight
         })
-    } else {
-        // Built-in electron aspect ratio lock works fine on Linux.
+    } else if (!isMac) {
+        // Built-in electron aspect ratio lock works fine on Linux but interferes with fullscreen on MacOS.
         win.setAspectRatio(TARGET_RATIO)
     }
 


### PR DESCRIPTION
don't setAspectRatio on MacOS as it interferes with fullscreen

fixes #91 