### PR TITLE
explicitly set fullscreenable: true to fix MacOS fullscreen issue #91

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,7 +367,7 @@ async function createWindow() {
             height: Math.round((outerW - extraWidth) / TARGET_RATIO) + extraHeight
         })
     } else {
-        // Built-in electron aspect ratio lock works fine on Linux but interferes with fullscreen on MacOS.
+        // Built-in electron aspect ratio lock works fine on Linux.
         win.setAspectRatio(TARGET_RATIO)
     }
 


### PR DESCRIPTION
Sorry @shy1132 I realize now my fix was wrong. Not sure why it seemed to work for a moment

This one is working rock solid for me. I've reversed my previous change so now the window will still be set to the desired aspect ratio on startup

Apologies for the runaround ...