### PR TITLE
add exit button in settings

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -56,6 +56,13 @@
         "controller_support": {
             "title": "Controller Support",
             "description": "Enables support for game controllers, including navigation and video playback controls. Requires an external controller, such as an Xbox Controller."
+        },
+        "exit": {
+            "title": "Exit",
+            "description": "Closes the program and returns to the desktop.",
+            "confirmation": "Are you sure you want to exit?",
+            "yes": "Yes",
+            "no": "No"
         }
     }
 }

--- a/preload/util/ui.js
+++ b/preload/util/ui.js
@@ -112,7 +112,7 @@ function link(options) {
                             options.createSubMenu
                                 ? options.createSubMenu()
                                 : undefined
-                        ]
+                        ].filter(Boolean)
                     }
                 }
             }


### PR DESCRIPTION
Add an exit button in settings to be able to exit out of the app when the app is full screen mode. Helpful in steam big picture mode when the steam overlay isn't working for external apps and cannot close it that way, and you want to use a controller to get back to the big picture mode. 