### PR TITLE
feat: add volume control module and indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4643,9 +4643,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-            "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+            "version": "7.5.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+            "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {

--- a/preload/modules/settings/index.js
+++ b/preload/modules/settings/index.js
@@ -81,6 +81,7 @@ function el(tag, attrs = {}, children = []) {
     return element;
 }
 
+
 function createOverlayDOM() {
     const createToggle = (configKey) => {
         return el('div', { className: `vt-toggle ${config[configKey] ? 'vt-toggle-on' : ''}`, dataConfig: configKey }, [
@@ -729,6 +730,7 @@ function setupEventListeners() {
         }
     }, true)
 
+    
     // Keyboard events - capture phase to intercept before YouTube
     // Block ALL keyboard input when overlay is visible to prevent Leanback from receiving it
     document.addEventListener('keydown', (e) => {
@@ -831,9 +833,10 @@ module.exports = async () => {
 
     locale = localeProvider.getLocale()
 
-    //inject settings css
+    // inject settings css
     const cssPath = path.join(__dirname, 'style.css')
-    const text = fs.readFileSync(cssPath, 'utf-8')
+    let text = fs.readFileSync(cssPath, 'utf-8')
+
 
     css.inject('settings', text)
 

--- a/preload/modules/settings/style.css
+++ b/preload/modules/settings/style.css
@@ -386,3 +386,50 @@
     outline: 2px solid #fff;
     outline-offset: 2px;
 }
+
+
+
+#vt-volume-indicator {
+        position: fixed;
+        bottom: 80px;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: rgba(0, 0, 0, 0.6);
+        color: white;
+        padding: 12px 24px;
+        border-radius: 16px;
+        display: flex;
+        align-items: center;
+        z-index: 999999;
+        opacity: 0;
+        transition: opacity 0.3s ease-in-out;
+        pointer-events: none;
+}
+
+#vt-volume-indicator.visible { opacity: 1; }
+
+.vt-volume-icon {
+            width: 24px; height: 24px; margin-right: 16px;
+            background-size: contain; background-repeat: no-repeat; background-position: center;
+}
+.vt-volume-icon.vt-volume-high { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 0 24 24' width='24px' fill='%23FFFFFF'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z'/%3E%3C/svg%3E"); }
+.vt-volume-icon.vt-volume-low { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 0 24 24' width='24px' fill='%23FFFFFF'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z'/%3E%3C/svg%3E"); }
+.vt-volume-icon.vt-volume-muted { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 0 24 24' width='24px' fill='%23FFFFFF'%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z'/%3E%3C/svg%3E"); }
+
+.vt-volume-bar-container {
+            width: 200px; height: 8px;
+            background-color: rgba(255, 255, 255, 0.3);
+            border-radius: 4px; overflow: hidden;
+}
+
+.vt-volume-bar {
+            height: 100%; width: 50%;
+            background-color: white; border-radius: 4px;
+            transition: width 0.1s linear;
+}
+
+.vt-volume-text {
+            font-size: 18px; font-weight: 500;
+            min-width: 55px; text-align: right;
+            margin-left: 16px;
+}

--- a/preload/modules/volume-control.js
+++ b/preload/modules/volume-control.js
@@ -1,0 +1,105 @@
+const functions = require('../util/functions');
+
+module.exports = async () => {
+    await functions.waitForCondition(() => !!document.body);
+
+    let volumeTimeout;
+
+    // Helper to create elements with attributes and children
+    function el(tag, attrs = {}, children = []) {
+        const element = document.createElement(tag)
+        for (const [key, value] of Object.entries(attrs)) {
+            if (key === 'className') {
+                element.className = value;
+            } else if (key === 'textContent') {
+                element.textContent = value;
+            } else if (key === 'style' && typeof value === 'object') {
+                Object.assign(element.style, value)
+            } else if (key.startsWith('data')) {
+                element.setAttribute(key.replace(/([A-Z])/g, '-$1').toLowerCase(), value)
+            } else {
+                element.setAttribute(key, value)
+            }
+        }
+
+        for (const child of children) {
+            if (child) element.appendChild(child)
+        }
+
+        return element;
+    }
+
+    function createVolumeIndicatorDOM() {
+        return el('div', { id: 'vt-volume-indicator' }, [
+            el('div', { id: 'vt-volume-icon', className: 'vt-volume-icon' }),
+            el('div', { className: 'vt-volume-bar-container' }, [
+                el('div', { id: 'vt-volume-bar', className: 'vt-volume-bar' })
+            ]),
+            el('span', { id: 'vt-volume-text', className: 'vt-volume-text' })
+        ]);
+    }
+
+    //create volume indicator
+    const volumeIndicatorElement = createVolumeIndicatorDOM();
+    document.body.appendChild(volumeIndicatorElement);
+
+    function showVolumeIndicator(volume) {
+        const indicator = document.getElementById('vt-volume-indicator');
+        const bar = document.getElementById('vt-volume-bar');
+        const text = document.getElementById('vt-volume-text');
+        const icon = document.getElementById('vt-volume-icon');
+        if (!indicator || !bar || !text || !icon) return;
+
+        const volumePercent = Math.round(volume * 100);
+        bar.style.width = `${volumePercent}%`;
+        text.textContent = `${volumePercent}%`;
+
+        // Update icon based on volume level
+        if (volumePercent === 0) {
+            icon.className = 'vt-volume-icon vt-volume-muted';
+        } else if (volumePercent < 50) {
+            icon.className = 'vt-volume-icon vt-volume-low';
+        } else {
+            icon.className = 'vt-volume-icon vt-volume-high';
+        }
+
+        indicator.classList.add('visible');
+
+        clearTimeout(volumeTimeout);
+        volumeTimeout = setTimeout(() => {
+            indicator.classList.remove('visible');
+        }, 1500);
+    }
+
+    // Volume controls
+    document.addEventListener('keydown', (e) => {
+        const overlay = document.getElementById('vt-settings-overlay-root');
+        if (overlay && !overlay.classList.contains('vt-settings-hidden')) return;
+
+        const video = document.querySelector('video');
+        if (!video) return;
+
+        let actionTaken = false;
+        const volumeStep = 0.05;
+
+        if (e.key === '+' || e.key === '=') {
+            if (video.muted) video.muted = false;
+            video.volume = Math.min(1, video.volume + volumeStep);
+            actionTaken = true;
+        } else if (e.key === '-') {
+            if (video.muted) video.muted = false;
+            video.volume = Math.max(0, video.volume - volumeStep);
+            actionTaken = true;
+        } else if (e.key.toLowerCase() === 'm') {
+            video.muted = !video.muted;
+            actionTaken = true;
+        }
+
+        if (actionTaken) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            showVolumeIndicator(video.muted ? 0 : video.volume);
+        }
+    }, true);
+};


### PR DESCRIPTION
I introduced a new feature for controlling the application's volume using the keyboard, along with a visual on-screen display.

**Key Features:**

- **Volume Adjustment:** Users can now press + or = to increase volume and - to decrease it.
- **Mute Toggle:** The m key can be used to quickly mute and unmute the audio.
- **Visual Indicator:** A sleek on-screen indicator appears briefly to show the current volume level whenever it's changed.
- **Modular Implementation:** The entire functionality is contained within a new, dedicated volume-control.js module to ensure the code is clean and easy to maintain.

Future plans:

- Controller support for this feature