### PR TITLE
[codex] Disable updater checks on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ const youtubeClientUserAgent = `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/19.lts.
 const userAgent = `VacuumTube/${package.version}` //for anything else
 
 const runningOnSteam = process.env.SteamOS === '1' && process.env.SteamGamepadUI === '1'
+const shouldCheckForUpdates = process.platform !== 'linux'
 
 let win;
 let config;
@@ -93,7 +94,9 @@ async function main() {
 
     await electron.app.whenReady()
 
-    autoUpdater.checkForUpdatesAndNotify()
+    if (shouldCheckForUpdates) {
+        autoUpdater.checkForUpdatesAndNotify()
+    }
 
     //general request modification
     electron.session.defaultSession.webRequest.onBeforeRequest((details, callback) => {


### PR DESCRIPTION
## Summary
- Skip electron-updater checks on Linux.
- Avoid Linux desktop sessions detecting a deb package target and attempting updater work from non-Debian environments.

## Root cause
VacuumTube calls autoUpdater.checkForUpdatesAndNotify() unconditionally at startup. On an Arch/KDE workstation, this produced a 'Found package-type: deb' log line and correlated with a shutdown authentication prompt mentioning a deb package.

## Validation
- Rebuilt with npm run linux:build-unpacked.
- Restarted the rebuilt dist/linux-unpacked launcher on Arch/KDE.
- Confirmed recent logs no longer show 'Found package-type: deb' or updater/polkit activity.