### PR TITLE
Fix macOS microphone permissions

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+    </dict>
+</plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+    </dict>
+</plist>

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const electron = require('electron')
 const { autoUpdater } = require('electron-updater')
 const path = require('path')
 const fs = require('fs')
+const childProcess = require('child_process')
 const chokidar = require('chokidar')
 const minimist = require('minimist')
 const stringArgv = require('string-argv')
@@ -44,11 +45,143 @@ VacuumTube overrides some things to identify properly, but this user agent has t
 const youtubeUserAgent = `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/26.lts.0-qa; compatible; VacuumTube/${package.version}` //for youtube, sent in innertube calls
 const youtubeClientUserAgent = `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/19.lts.0-qa; compatible; VacuumTube/${package.version}` //for youtube, somewhere in client scripts this matters because it parses cobalt version explicitly from the user agent, which affects playability because cobalt 26 "should" work with widevine, when we can't support that
 const userAgent = `VacuumTube/${package.version}` //for anything else
+const youtubeOrigin = 'https://www.youtube.com'
+const microphonePrivacySettingsUrl = 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone'
+const appId = package.build?.appId || 'rocks.shy.VacuumTube'
 
 const runningOnSteam = process.env.SteamOS === '1' && process.env.SteamGamepadUI === '1'
 
 let win;
 let config;
+let microphonePromptPromise = null;
+let lastDeniedMicrophoneLog = 0;
+
+function getUrlOrigin(value) {
+    if (!value) return null;
+
+    try {
+        const origin = new URL(value).origin
+        return origin === 'null' ? null : origin;
+    } catch {
+        return null;
+    }
+}
+
+function isYoutubePermissionRequest(webContents, requestingOrigin, details = {}) {
+    const requestingFrameOrigin = getUrlOrigin(details.requestingUrl)
+        || getUrlOrigin(details.securityOrigin)
+        || getUrlOrigin(requestingOrigin)
+
+    if (requestingFrameOrigin) {
+        return requestingFrameOrigin === youtubeOrigin
+    }
+
+    return getUrlOrigin(webContents?.getURL?.()) === youtubeOrigin
+}
+
+function isAudioMediaRequest(details = {}) {
+    if (Array.isArray(details.mediaTypes)) {
+        return details.mediaTypes.length > 0 && details.mediaTypes.every((type) => type === 'audio')
+    }
+
+    return details.mediaType === 'audio'
+}
+
+function getMicrophonePermissionStatus() {
+    if (process.platform !== 'darwin') return 'unsupported';
+
+    try {
+        return electron.systemPreferences.getMediaAccessStatus('microphone')
+    } catch (error) {
+        console.error('[Permissions] Failed to get microphone access status:', error)
+        return 'unknown'
+    }
+}
+
+async function requestMicrophonePermissionStatus() {
+    if (process.platform !== 'darwin') return 'unsupported';
+
+    const status = getMicrophonePermissionStatus()
+    if (status !== 'not-determined') return status;
+
+    if (!microphonePromptPromise) {
+        microphonePromptPromise = electron.systemPreferences.askForMediaAccess('microphone')
+        .catch((error) => {
+            console.error('[Permissions] Failed to request microphone access:', error)
+            return false
+        })
+        .finally(() => {
+            microphonePromptPromise = null;
+        })
+    }
+
+    await microphonePromptPromise
+
+    return getMicrophonePermissionStatus()
+}
+
+async function requestMicrophonePermission() {
+    const status = await requestMicrophonePermissionStatus()
+    return status === 'granted';
+}
+
+async function resetMicrophonePermissionStatus() {
+    if (process.platform !== 'darwin') return 'unsupported';
+
+    return await new Promise((resolve) => {
+        childProcess.execFile('/usr/bin/tccutil', [ 'reset', 'Microphone', appId ], (error) => {
+            if (error) {
+                console.error('[Permissions] Failed to reset microphone access:', error)
+                resolve('unknown')
+                return;
+            }
+
+            resolve(getMicrophonePermissionStatus())
+        })
+    })
+}
+
+function isMicrophonePermissionGranted() {
+    return getMicrophonePermissionStatus() === 'granted'
+}
+
+function logDeniedMicrophoneRequest(details = {}) {
+    const now = Date.now()
+    if ((now - lastDeniedMicrophoneLog) < 5000) return;
+
+    lastDeniedMicrophoneLog = now;
+    console.log('[Permissions] Denied microphone media request', {
+        status: getMicrophonePermissionStatus(),
+        requestingUrl: details.requestingUrl,
+        securityOrigin: details.securityOrigin
+    })
+}
+
+function setupMicrophonePermissionHandlers() {
+    if (process.platform !== 'darwin') return;
+
+    electron.session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin, details = {}) => {
+        if (permission !== 'media') return false;
+        if (!isYoutubePermissionRequest(webContents, requestingOrigin, details)) return false;
+        if (!isAudioMediaRequest(details)) return false;
+
+        return isMicrophonePermissionGranted()
+    })
+
+    electron.session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details = {}) => {
+        if (permission !== 'media' || !isYoutubePermissionRequest(webContents, null, details) || !isAudioMediaRequest(details)) {
+            callback(false)
+            return;
+        }
+
+        const granted = isMicrophonePermissionGranted()
+        if (!granted) {
+            logDeniedMicrophoneRequest(details)
+        }
+
+        callback(granted)
+    })
+}
 
 async function main() {
     if (argv['version'] || argv['v']) {
@@ -101,6 +234,7 @@ async function main() {
     await electron.app.whenReady()
 
     autoUpdater.checkForUpdatesAndNotify()
+    setupMicrophonePermissionHandlers()
 
     //general request modification
     electron.session.defaultSession.webRequest.onBeforeRequest((details, callback) => {
@@ -254,6 +388,35 @@ async function main() {
         } else {
             return null;
         }
+    })
+
+    electron.ipcMain.handle('get-microphone-permission-status', () => {
+        return getMicrophonePermissionStatus()
+    })
+
+    electron.ipcMain.handle('request-microphone-permission', () => {
+        return requestMicrophonePermissionStatus()
+    })
+
+    electron.ipcMain.handle('reset-microphone-permission', () => {
+        return resetMicrophonePermissionStatus()
+    })
+
+    electron.ipcMain.handle('open-microphone-privacy-settings', async () => {
+        if (process.platform !== 'darwin') return false;
+
+        try {
+            await electron.shell.openExternal(microphonePrivacySettingsUrl)
+            return true;
+        } catch (error) {
+            console.error('[Permissions] Failed to open microphone privacy settings:', error)
+            return false;
+        }
+    })
+
+    electron.ipcMain.handle('relaunch-app', () => {
+        electron.app.relaunch()
+        electron.app.quit()
     })
 
     // Userstyles

--- a/locale/en.json
+++ b/locale/en.json
@@ -73,6 +73,32 @@
             "title": "Pause on Blur",
             "description": "Pause current video when VacuumTube loses focus (e.g. tabbing out or minimizing the window)"
         },
+        "permissions": {
+            "title": "Permissions",
+            "description": "Manage macOS permissions used by VacuumTube.",
+            "microphone_title": "Microphone",
+            "microphone_description": "Used only when you start YouTube voice search.",
+            "status_label": "Status",
+            "status_loading": "Checking microphone permission...",
+            "request_microphone": "Request Microphone Access",
+            "open_microphone_settings": "Open macOS Microphone Settings",
+            "reset_microphone": "Troubleshooting: Reset Permission Prompt",
+            "relaunch_app": "Relaunch VacuumTube",
+            "restart_required": "Changes made in macOS Settings require relaunching VacuumTube.",
+            "request_granted": "Microphone access is allowed. No permission prompt is needed.",
+            "request_not_determined": "macOS still has not shown a permission prompt. Use Reset Permission Prompt, then try again.",
+            "request_denied_help": "macOS will not show the permission prompt again while access is denied. Turn it on in macOS Settings, then relaunch VacuumTube.",
+            "request_failed": "VacuumTube could not request microphone access. Open macOS Settings and relaunch the app after changing access.",
+            "resetting_microphone": "Resetting the saved macOS microphone decision...",
+            "statuses": {
+                "not-determined": "Not Requested",
+                "granted": "Allowed",
+                "denied": "Denied",
+                "restricted": "Restricted",
+                "unknown": "Unknown",
+                "unsupported": "Unsupported"
+            }
+        },
         "userstyles": {
             "title": "Custom CSS (Userstyles)",
             "description": "Place .css files in the userstyles folder to customize the interface. Changes are applied automatically",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
         "mac": {
             "icon": "./assets/icon.icns",
             "category": "public.app-category.video",
+            "entitlements": "build/entitlements.mac.plist",
+            "entitlementsInherit": "build/entitlements.mac.inherit.plist",
+            "extendInfo": {
+                "NSMicrophoneUsageDescription": "VacuumTube uses the microphone only when you use YouTube voice search."
+            },
             "target": [
                 {
                     "target": "dmg",

--- a/preload/modules/fix-voice.js
+++ b/preload/modules/fix-voice.js
@@ -1,7 +1,95 @@
 //fix voice search
 
+const { ipcRenderer } = require('electron')
 const configOverrides = require('../util/configOverrides')
+const functions = require('../util/functions')
+
+let pendingAudioCapture = null;
+
+function hasAudioConstraint(constraints) {
+    if (!constraints || typeof constraints !== 'object') return false;
+    if (!Object.prototype.hasOwnProperty.call(constraints, 'audio')) return false;
+
+    return constraints.audio !== false;
+}
+
+function createNotAllowedError(message) {
+    if (typeof DOMException === 'function') {
+        return new DOMException(message, 'NotAllowedError')
+    }
+
+    const error = new Error(message)
+    error.name = 'NotAllowedError'
+    return error;
+}
+
+async function getNativeMicrophoneStatus() {
+    try {
+        return await ipcRenderer.invoke('request-microphone-permission')
+    } catch (error) {
+        console.error('[Voice] Failed to request microphone permission:', error)
+        return 'unknown'
+    }
+}
+
+function guardGetUserMedia() {
+    if (process.platform !== 'darwin') return;
+    if (!navigator.mediaDevices?.getUserMedia) return;
+    if (navigator.mediaDevices.getUserMedia.vtMicrophoneGuarded) return;
+
+    const originalGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices)
+
+    const guardedGetUserMedia = (constraints) => {
+        if (!hasAudioConstraint(constraints)) {
+            return originalGetUserMedia(constraints)
+        }
+
+        if (pendingAudioCapture) {
+            return pendingAudioCapture;
+        }
+
+        pendingAudioCapture = (async () => {
+            const status = await getNativeMicrophoneStatus()
+            if (status !== 'granted') {
+                throw createNotAllowedError(`Microphone permission is ${status}`)
+            }
+
+            return originalGetUserMedia(constraints)
+        })()
+        .finally(() => {
+            pendingAudioCapture = null;
+        })
+
+        return pendingAudioCapture;
+    }
+
+    guardedGetUserMedia.vtMicrophoneGuarded = true;
+
+    try {
+        navigator.mediaDevices.getUserMedia = guardedGetUserMedia;
+    } catch {
+    }
+
+    if (navigator.mediaDevices.getUserMedia !== guardedGetUserMedia) {
+        try {
+            Object.defineProperty(navigator.mediaDevices, 'getUserMedia', {
+                configurable: true,
+                writable: true,
+                value: guardedGetUserMedia
+            })
+        } catch (error) {
+            console.error('[Voice] Failed to install getUserMedia guard:', error)
+        }
+    }
+}
 
 module.exports = () => {
     configOverrides.overrideEnv('env_enableMediaStreams', true)
+
+    guardGetUserMedia()
+
+    if (process.platform === 'darwin') {
+        functions.waitForCondition(() => !!navigator.mediaDevices?.getUserMedia)
+        .then(guardGetUserMedia)
+    }
 }

--- a/preload/modules/settings/index.js
+++ b/preload/modules/settings/index.js
@@ -29,6 +29,7 @@ const scrollOffsets = {}
 let overlayVisible = false;
 let currentTabIndex = 0;
 let currentItemIndex = 0;
+let microphonePermissionStatus = 'unknown';
 
 //settings
 let tabs = [
@@ -46,6 +47,7 @@ let tabs = [
     { id: 'no_window_decorations' },
     { id: 'keep_on_top', func: (value) => ipcRenderer.invoke('set-on-top', value) },
     { id: 'pause_on_blur' },
+    { id: 'permissions', hide: process.platform !== 'darwin' },
     { id: 'userstyles' },
     { id: 'touch_overlay' },
     { id: 'controller_support' }
@@ -96,6 +98,58 @@ function createOverlayDOM() {
     }
 
     const customContent = {
+
+        'permissions':
+        el('div', { className: 'vt-permissions-section' }, [
+            el('p', { className: 'vt-permissions-description', textContent: locale.settings.permissions.description }),
+            el('div', { className: 'vt-permission-card' }, [
+                el('div', { className: 'vt-setting-info' }, [
+                    el('span', { className: 'vt-setting-title', textContent: locale.settings.permissions.microphone_title }),
+                    el('span', { className: 'vt-setting-description', textContent: locale.settings.permissions.microphone_description }),
+                    el('span', {
+                        className: 'vt-permission-status',
+                        id: 'vt-microphone-status',
+                        textContent: formatMicrophonePermissionStatus(microphonePermissionStatus)
+                    }),
+                    el('span', {
+                        className: 'vt-permission-note',
+                        textContent: locale.settings.permissions.restart_required
+                    }),
+                    el('span', {
+                        className: 'vt-permission-message',
+                        id: 'vt-microphone-message'
+                    })
+                ])
+            ]),
+            el('div', {
+                className: 'vt-button',
+                dataAction: 'request-microphone-permission',
+                dataIndex: '0'
+            }, [
+                el('span', { textContent: locale.settings.permissions.request_microphone })
+            ]),
+            el('div', {
+                className: 'vt-button',
+                dataAction: 'open-microphone-privacy-settings',
+                dataIndex: '1'
+            }, [
+                el('span', { textContent: locale.settings.permissions.open_microphone_settings })
+            ]),
+            el('div', {
+                className: 'vt-button',
+                dataAction: 'reset-microphone-permission',
+                dataIndex: '2'
+            }, [
+                el('span', { textContent: locale.settings.permissions.reset_microphone })
+            ]),
+            el('div', {
+                className: 'vt-button',
+                dataAction: 'relaunch-app',
+                dataIndex: '3'
+            }, [
+                el('span', { textContent: locale.settings.permissions.relaunch_app })
+            ])
+        ]),
 
         'userstyles': 
         el('div', { className: 'vt-userstyles-section' }, [
@@ -191,6 +245,68 @@ function getOverlay() {
     return document.getElementById('vt-settings-overlay-root');
 }
 
+function getMicrophonePermissionLabel(status) {
+    return locale.settings.permissions.statuses[status] || locale.settings.permissions.statuses.unknown || status;
+}
+
+function formatMicrophonePermissionStatus(status) {
+    return `${locale.settings.permissions.status_label}: ${getMicrophonePermissionLabel(status)}`
+}
+
+function setMicrophonePermissionStatus(status) {
+    microphonePermissionStatus = status || 'unknown'
+
+    const statusElement = document.getElementById('vt-microphone-status')
+    if (!statusElement) return;
+
+    statusElement.textContent = formatMicrophonePermissionStatus(microphonePermissionStatus)
+    statusElement.dataset.status = microphonePermissionStatus;
+}
+
+function setMicrophonePermissionLoading() {
+    const statusElement = document.getElementById('vt-microphone-status')
+    if (!statusElement) return;
+
+    statusElement.textContent = locale.settings.permissions.status_loading
+    delete statusElement.dataset.status;
+}
+
+function setMicrophonePermissionMessage(message, type = 'info') {
+    const messageElement = document.getElementById('vt-microphone-message')
+    if (!messageElement) return;
+
+    messageElement.textContent = message || ''
+    messageElement.dataset.type = type;
+}
+
+function setMicrophoneRequestMessage(status) {
+    if (status === 'granted') {
+        setMicrophonePermissionMessage(locale.settings.permissions.request_granted, 'success')
+    } else if (status === 'not-determined') {
+        setMicrophonePermissionMessage(locale.settings.permissions.request_not_determined, 'warning')
+    } else if (status === 'denied' || status === 'restricted') {
+        setMicrophonePermissionMessage(locale.settings.permissions.request_denied_help, 'warning')
+    } else {
+        setMicrophonePermissionMessage(locale.settings.permissions.request_failed, 'warning')
+    }
+}
+
+async function refreshMicrophonePermissionStatus() {
+    if (process.platform !== 'darwin') return;
+
+    const statusElement = document.getElementById('vt-microphone-status')
+    if (!statusElement) return;
+
+    setMicrophonePermissionLoading()
+
+    try {
+        setMicrophonePermissionStatus(await ipcRenderer.invoke('get-microphone-permission-status'))
+    } catch (error) {
+        console.error('[Settings Overlay] Failed to load microphone permission status:', error)
+        setMicrophonePermissionStatus('unknown')
+    }
+}
+
 async function refreshUserstylesList() {
     const listContainer = document.getElementById('vt-userstyles-list')
     if (!listContainer) return
@@ -254,6 +370,7 @@ function showOverlay() {
     overlay.focus()
 
     refreshUserstylesList()
+    refreshMicrophonePermissionStatus()
 
     currentTabIndex = 0;
     currentItemIndex = 0;
@@ -502,6 +619,12 @@ function selectTab(index) {
 
         const activePanel = overlay.querySelector(`.vt-content-panel[data-panel="${tabId}"]`)
         if (activePanel) activePanel.classList.add('vt-panel-active')
+
+        if (tabId === 'permissions') {
+            refreshMicrophonePermissionStatus()
+        } else if (tabId === 'userstyles') {
+            refreshUserstylesList()
+        }
     }
 }
 
@@ -549,6 +672,36 @@ function toggleUserstyle(filename) {
     window.dispatchEvent(new CustomEvent('vt-userstyle-toggle', {
         detail: { filename, enabled: isCurrentlyDisabled }
     }))
+}
+
+async function handleButtonAction(action) {
+    try {
+        if (action === 'open-userstyles-folder') {
+            await ipcRenderer.invoke('open-userstyles-folder')
+        } else if (action === 'request-microphone-permission') {
+            setMicrophonePermissionLoading()
+            setMicrophonePermissionMessage('')
+            const status = await ipcRenderer.invoke('request-microphone-permission')
+            setMicrophonePermissionStatus(status)
+            setMicrophoneRequestMessage(status)
+        } else if (action === 'reset-microphone-permission') {
+            setMicrophonePermissionLoading()
+            setMicrophonePermissionMessage(locale.settings.permissions.resetting_microphone)
+            await ipcRenderer.invoke('reset-microphone-permission')
+            const status = await ipcRenderer.invoke('request-microphone-permission')
+            setMicrophonePermissionStatus(status)
+            setMicrophoneRequestMessage(status)
+        } else if (action === 'open-microphone-privacy-settings') {
+            await ipcRenderer.invoke('open-microphone-privacy-settings')
+        } else if (action === 'relaunch-app') {
+            await ipcRenderer.invoke('relaunch-app')
+        }
+    } catch (error) {
+        console.error(`[Settings Overlay] Failed to run button action ${action}:`, error)
+        if (action === 'request-microphone-permission') {
+            setMicrophonePermissionStatus('unknown')
+        }
+    }
 }
 
 function getItemCount() {
@@ -672,9 +825,7 @@ function handleKeyDown(e) {
                 const button = panel.querySelector(`.vt-button[data-index="${currentItemIndex}"]`)
                 if (button) {
                     const action = button.dataset.action;
-                    if (action === 'open-userstyles-folder') {
-                        ipcRenderer.invoke('open-userstyles-folder')
-                    }
+                    handleButtonAction(action)
 
                     return;
                 }
@@ -775,9 +926,7 @@ function setupEventListeners() {
         const button = e.target.closest('.vt-button')
         if (button) {
             const action = button.dataset.action;
-            if (action === 'open-userstyles-folder') {
-                ipcRenderer.invoke('open-userstyles-folder')
-            }
+            handleButtonAction(action)
 
             return;
         }

--- a/preload/modules/settings/style.css
+++ b/preload/modules/settings/style.css
@@ -260,6 +260,78 @@
     text-align: center;
 }
 
+.vt-permissions-section {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.vt-permissions-description {
+    font-size: 14px;
+    color: #aaa;
+    margin-bottom: 20px;
+    line-height: 1.5;
+    flex-shrink: 0;
+}
+
+.vt-permission-card {
+    display: flex;
+    padding: 20px 24px;
+    background: #2a2a2a;
+    border-radius: 12px;
+    margin-bottom: 12px;
+    flex-shrink: 0;
+}
+
+.vt-permission-status {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    margin-top: 14px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: #3a3a3a;
+    color: #fff;
+    font-size: 14px;
+}
+
+.vt-permission-status[data-status="granted"] {
+    background: #1f5f3a;
+}
+
+.vt-permission-status[data-status="denied"],
+.vt-permission-status[data-status="restricted"] {
+    background: #703030;
+}
+
+.vt-permission-note {
+    margin-top: 12px;
+    color: #aaa;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.vt-permission-message {
+    margin-top: 12px;
+    color: #aaa;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.vt-permission-message[data-type="success"] {
+    color: #9ee0b5;
+}
+
+.vt-permission-message[data-type="warning"] {
+    color: #ffc777;
+}
+
+.vt-permissions-section .vt-button {
+    margin-bottom: 12px;
+}
+
 .vt-userstyles-section {
     display: flex;
     flex-direction: column;

--- a/preload/modules/voice-privacy-notice.js
+++ b/preload/modules/voice-privacy-notice.js
@@ -3,6 +3,8 @@
 const configOverrides = require('../util/configOverrides')
 
 module.exports = () => {
+    if (process.platform === 'darwin') return;
+
     configOverrides.tectonicConfigOverrides.push({
         featureSwitches: {
             hasSamsungVoicePrivacyNotice: true


### PR DESCRIPTION
Add native macOS microphone permission handling, hardened-runtime audio input entitlements, and a Permissions settings panel for YouTube voice search.

Prevent repeated Leanback permission prompts by disabling the Samsung voice notice on macOS and de-duping audio getUserMedia requests.