### PR TITLE
feat: selective codec blocking

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -42,8 +42,18 @@
             "description": "Hides YouTube Shorts from the homepage"
         },
         "h264ify": {
-            "title": "Force H.264 (h264ify)",
-            "description": "Forces YouTube to only stream videos in the H.264 codec. This can help with performance and battery life on slower devices, but prevents you from watching anything above 1080p. Relaunch after toggling"
+            "title": "Filter Video Codecs",
+            "description": "Codec filtering options. Relaunch after toggling any of the options.",
+            "enable_title": "Enable codec filter (h264ify)",
+            "enable_description": "Enables the codec filter. This can help with performance and battery life on slower devices, but may reduce the available resolutions.",
+            "disable_webm_title": "Disable WebM",
+            "disable_webm_description": "Block WebM container streams.",
+            "disable_vp8_title": "Disable VP8",
+            "disable_vp8_description": "Block VP8 streams.",
+            "disable_vp9_title": "Disable VP9",
+            "disable_vp9_description": "Block VP9 streams.",
+            "disable_av1_title": "Disable AV1",
+            "disable_av1_description": "Block AV1 streams."
         },
         "hardware_decoding": {
             "title": "Hardware Decoding",

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,11 @@ const defaults = {
     dislikes: false, //readds youtube dislikes via https://www.returnyoutubedislike.com/
     remove_super_resolution: false, //block "super resolution" (ai upscaled qualities)
     hide_shorts: false, //hide youtube shorts from homepage
-    h264ify: false, //block non-h264 codecs for performance on slow devices
+    h264ify: false, // enable codec blocking feature 
+    h264ify_disable_webm: true, //when h264ify is enabled, block webm container streams
+    h264ify_disable_vp8: true, //when h264ify is enabled, block vp8 streams
+    h264ify_disable_vp9: true, //when h264ify is enabled, block vp9 streams
+    h264ify_disable_av1: true, //when h264ify is enabled, block av1 streams
     hardware_decoding: true, //use hardware gpu video decoding
     wayland_hdr: false, //whether or not to enable wayland color management, which allows hdr but sometimes has issues on non-hdr systems
     low_memory_mode: false, //enables env_isLimitedMemory

--- a/src/preload/modules/h264ify.js
+++ b/src/preload/modules/h264ify.js
@@ -17,12 +17,11 @@ module.exports = () => {
 
     function makeModifiedTypeChecker() {
         return (type) => {
-            let disallowedTypes = ['webm', 'vp8', 'vp9', 'av01']
-
-            for (let disallowedType of disallowedTypes) {
-                if (type.includes(disallowedType)) {
-                    return '';
-                }
+            if (config.h264ify_disable_webm && type.includes('webm') ||
+                config.h264ify_disable_vp8 && type.includes('vp8') ||
+                config.h264ify_disable_vp9 && type.includes('vp9') ||
+                config.h264ify_disable_av1 && type.includes('av01')) {
+                return '';
             }
 
             return canPlayType(type);

--- a/src/preload/modules/settings/index.js
+++ b/src/preload/modules/settings/index.js
@@ -72,6 +72,7 @@ for (let item of tabs) {
 
 //custom panels (settings with their own interface instead of a single toggle), keyed by tab id
 const panelModules = [
+    require('./panels/h264ify'),
     require('./panels/mac-permissions'),
     require('./panels/userstyles')
 ]
@@ -275,6 +276,7 @@ function activateFocusedItem() {
     if (!focused) return;
 
     if (focused.classList.contains('vt-setting-item')) {
+        if (focused.classList.contains('vt-setting-item-inactive')) return;
         if (focused.dataset.setting) toggleSetting(focused.dataset.setting)
     } else if (focused.classList.contains('vt-button')) {
         handleButtonAction(focused.dataset.action)
@@ -457,6 +459,7 @@ function setupEventListeners() {
 
         const item = e.target.closest('.vt-setting-item')
         if (item) {
+            if (item.classList.contains('vt-setting-item-inactive')) return;
             const configKey = item.dataset.setting;
             if (configKey) toggleSetting(configKey)
             return;
@@ -537,6 +540,10 @@ module.exports = async () => {
                     toggle.classList.toggle('vt-toggle-on', config[configKey])
                 }
             })
+
+            for (const panel of panelModules) {
+                panel.onConfigUpdate?.(config)
+            }
         }
     })
 

--- a/src/preload/modules/settings/panels/h264ify.js
+++ b/src/preload/modules/settings/panels/h264ify.js
@@ -1,0 +1,120 @@
+const { el, createToggle } = require('../dom')
+const configManager = require('../../../config')
+
+let locale = null;
+
+function getConfig() {
+    return configManager.get()
+}
+
+function updateInactiveState() {
+    const root = document.querySelector('.vt-content-panel[data-panel="h264ify"]')
+    if (!root) return;
+
+    const isEnabled = !!getConfig().h264ify
+
+    root.querySelectorAll('.vt-setting-item[data-h264ify-codec="true"]').forEach((item) => {
+        item.classList.toggle('vt-setting-item-inactive', !isEnabled)
+        item.setAttribute('aria-disabled', isEnabled ? 'false' : 'true')
+    })
+}
+
+module.exports = {
+    id: 'h264ify',
+
+    init(ctx) {
+        locale = ctx.locale
+    },
+
+    render() {
+        const config = getConfig()
+
+        return el('div', { className: 'vt-h264ify-section' }, [
+            el('div', {
+                className: 'vt-setting-item',
+                dataSetting: 'h264ify',
+                dataIndex: '0'
+            }, [
+                el('div', { className: 'vt-setting-info' }, [
+                    el('span', { className: 'vt-setting-title', textContent: locale.settings.h264ify.enable_title }),
+                    el('span', { className: 'vt-setting-description', textContent: locale.settings.h264ify.enable_description })
+                ]),
+                el('div', { className: 'vt-setting-control' }, [
+                    createToggle('h264ify', config.h264ify)
+                ])
+            ]),
+            el('div', {
+                className: `vt-setting-item ${config.h264ify ? '' : 'vt-setting-item-inactive'}`.trim(),
+                dataSetting: 'h264ify_disable_webm',
+                dataH264ifyCodec: 'true',
+                dataIndex: '1',
+                ariaDisabled: config.h264ify ? 'false' : 'true'
+            }, [
+                el('div', { className: 'vt-setting-info' }, [
+                    el('span', { className: 'vt-setting-title', textContent: locale.settings.h264ify.disable_webm_title }),
+                    el('span', { className: 'vt-setting-description', textContent: locale.settings.h264ify.disable_webm_description })
+                ]),
+                el('div', { className: 'vt-setting-control' }, [
+                    createToggle('h264ify_disable_webm', config.h264ify_disable_webm)
+                ])
+            ]),
+            el('div', {
+                className: `vt-setting-item ${config.h264ify ? '' : 'vt-setting-item-inactive'}`.trim(),
+                dataSetting: 'h264ify_disable_vp8',
+                dataH264ifyCodec: 'true',
+                dataIndex: '2',
+                ariaDisabled: config.h264ify ? 'false' : 'true'
+            }, [
+                el('div', { className: 'vt-setting-info' }, [
+                    el('span', { className: 'vt-setting-title', textContent: locale.settings.h264ify.disable_vp8_title }),
+                    el('span', { className: 'vt-setting-description', textContent: locale.settings.h264ify.disable_vp8_description })
+                ]),
+                el('div', { className: 'vt-setting-control' }, [
+                    createToggle('h264ify_disable_vp8', config.h264ify_disable_vp8)
+                ])
+            ]),
+            el('div', {
+                className: `vt-setting-item ${config.h264ify ? '' : 'vt-setting-item-inactive'}`.trim(),
+                dataSetting: 'h264ify_disable_vp9',
+                dataH264ifyCodec: 'true',
+                dataIndex: '3',
+                ariaDisabled: config.h264ify ? 'false' : 'true'
+            }, [
+                el('div', { className: 'vt-setting-info' }, [
+                    el('span', { className: 'vt-setting-title', textContent: locale.settings.h264ify.disable_vp9_title }),
+                    el('span', { className: 'vt-setting-description', textContent: locale.settings.h264ify.disable_vp9_description })
+                ]),
+                el('div', { className: 'vt-setting-control' }, [
+                    createToggle('h264ify_disable_vp9', config.h264ify_disable_vp9)
+                ])
+            ]),
+            el('div', {
+                className: `vt-setting-item ${config.h264ify ? '' : 'vt-setting-item-inactive'}`.trim(),
+                dataSetting: 'h264ify_disable_av1',
+                dataH264ifyCodec: 'true',
+                dataIndex: '4',
+                ariaDisabled: config.h264ify ? 'false' : 'true'
+            }, [
+                el('div', { className: 'vt-setting-info' }, [
+                    el('span', { className: 'vt-setting-title', textContent: locale.settings.h264ify.disable_av1_title }),
+                    el('span', { className: 'vt-setting-description', textContent: locale.settings.h264ify.disable_av1_description })
+                ]),
+                el('div', { className: 'vt-setting-control' }, [
+                    createToggle('h264ify_disable_av1', config.h264ify_disable_av1)
+                ])
+            ])
+        ])
+    },
+
+    onShow() {
+        updateInactiveState()
+    },
+
+    onConfigUpdate(config) {
+        if (!config) return;
+
+        if (config.h264ify === undefined) return;
+
+        updateInactiveState()
+    }
+}

--- a/src/preload/modules/settings/style.css
+++ b/src/preload/modules/settings/style.css
@@ -181,6 +181,15 @@
     outline-offset: -2px;
 }
 
+.vt-setting-item.vt-setting-item-inactive {
+    opacity: 0.55;
+    cursor: default;
+}
+
+.vt-setting-item.vt-setting-item-inactive:hover {
+    background: #2a2a2a;
+}
+
 .vt-setting-info {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Adds the possibility to selectively disable single codecs instead of the global h264 fallback by kicking out all of them.

This implements #192.

Did a quick test with known videos, disabled only av01, works fine.