### PR TITLE
Trim macOS Electron locale resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,16 @@
         "mac": {
             "icon": "./assets/icon.icns",
             "category": "public.app-category.video",
+            "electronLanguages": [
+                "en",
+                "de",
+                "nl",
+                "tr",
+                "hr",
+                "sv",
+                "id",
+                "sr"
+            ],
             "entitlements": "build/entitlements.mac.plist",
             "entitlementsInherit": "build/entitlements.mac.inherit.plist",
             "extendInfo": {


### PR DESCRIPTION
## Summary

Limit the Electron locale resources included in macOS builds to the locales currently shipped by VacuumTube.

## Why

The default macOS Electron package includes many locale resource folders that VacuumTube does not currently ship translations for. Limiting these resources reduces the macOS app bundle size without changing app runtime behavior.

## Test

Built unpacked macOS arm64 apps with electron-builder in a temporary copy:

- Before: 280M, 55 Electron locale folders
- After: 238M, 8 Electron locale folders

The retained Electron locale folders are:

- en
- de
- nl
- tr
- hr
- sv
- id
- sr