### PR TITLE
Upload macOS ZIP release artifact

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -59,6 +59,7 @@ jobs:
         if: matrix.platform == 'mac'
         run: |
           gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-universal.dmg --clobber
+          gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-universal.zip --clobber
           gh release upload ${{ github.event.release.tag_name }} dist/latest-mac.yml --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Upload the macOS ZIP artifact when publishing release assets.

## Why

The macOS build configuration already produces both a DMG and ZIP target, and the release workflow uploads `latest-mac.yml`. Uploading the ZIP alongside the DMG keeps the published release assets aligned with the generated macOS artifacts.

## Test

- Parsed `.github/workflows/build-and-release.yml` as YAML
- Ran `git diff --check`
