### PR TITLE
Limit macOS packaged app files

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
                 "id",
                 "sr"
             ],
+            "files": [
+                "src/**",
+                "locale/*.json",
+                "assets/icon.png"
+            ],
             "entitlements": "build/entitlements.mac.plist",
             "entitlementsInherit": "build/entitlements.mac.inherit.plist",
             "extendInfo": {


### PR DESCRIPTION
## Summary

Limit the files included in macOS app packages to the runtime app files, locale JSON, and runtime icon asset.

## Why

The default package contents include repo-only files that are not needed at runtime, such as Flatpak packaging files, README files, and extra platform icon assets. This keeps the macOS app archive focused on the files the app actually uses.

## Test

Built an unpacked macOS arm64 app with electron-builder in a temporary copy:

- App bundle: 238M -> 236M
- app.asar: 6.4M -> 4.5M
- Electron locale folders retained: 8

Verified key runtime files are still present in app.asar, and repo-only files are removed:

- flatpak entries: 8 -> 0
- README entries: 2 -> 0
- extra icon entries: 11 -> 0
