### PR TITLE
Split macOS release artifacts by architecture

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -58,7 +58,11 @@ jobs:
       - name: Upload Mac artifacts to release
         if: matrix.platform == 'mac'
         run: |
+          gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-x64.dmg --clobber
+          gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-arm64.dmg --clobber
           gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-universal.dmg --clobber
+          gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-x64.zip --clobber
+          gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-arm64.zip --clobber
           gh release upload ${{ github.event.release.tag_name }} dist/VacuumTube-universal.zip --clobber
           gh release upload ${{ github.event.release.tag_name }} dist/latest-mac.yml --clobber
         env:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ If you don't know the difference, pick the Installer.
 
 Note that macOS builds are not yet signed, so they do not auto-update. For now, please periodically check for updates.
 
+- [Apple Silicon / M-series](https://github.com/shy1132/VacuumTube/releases/latest/download/VacuumTube-arm64.dmg)
+- [Intel](https://github.com/shy1132/VacuumTube/releases/latest/download/VacuumTube-x64.dmg)
 - [Universal](https://github.com/shy1132/VacuumTube/releases/latest/download/VacuumTube-universal.dmg)
 
 ### Linux

--- a/package.json
+++ b/package.json
@@ -105,12 +105,16 @@
                 {
                     "target": "dmg",
                     "arch": [
+                        "x64",
+                        "arm64",
                         "universal"
                     ]
                 },
                 {
                     "target": "zip",
                     "arch": [
+                        "x64",
+                        "arm64",
                         "universal"
                     ]
                 }


### PR DESCRIPTION
## Summary

Build and publish separate macOS DMG and ZIP artifacts for Intel, Apple Silicon, and Universal builds.

## Why

The Universal macOS artifact remains available as a compatibility fallback, but native architecture artifacts give users a smaller direct download for their Mac. The README now points Apple Silicon and Intel users to the matching DMG first.

## Test

- Parsed `package.json`
- Parsed `.github/workflows/build-and-release.yml` as YAML
- Ran `git diff --check`
- Built unpacked macOS arm64 app with electron-builder
- Built unpacked macOS x64 app with electron-builder

Build outputs from the temporary validation copy:

- arm64 app: 238M, 8 Electron locale folders
- x64 app: 237M, 8 Electron locale folders
