### PR TITLE
Prevent legacy config migration from overwriting config.json

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,7 +39,7 @@ const defaults = {
 }
 
 function init(overrides = {}) {
-    if (fs.existsSync(legacyStateFile)) {
+    if (fs.existsSync(legacyStateFile) && !fs.existsSync(configFile)) {
         console.log('[config] Migrating legacy state.json')
         fs.renameSync(legacyStateFile, configFile)
     }


### PR DESCRIPTION
## Summary

Only migrate legacy `state.json` when `config.json` does not already exist. This preserves an existing configuration when both files are present.

## Root cause

Startup migrated `state.json` whenever it existed, even when a current `config.json` was already present.

## Testing

- Verified legacy `state.json` migrates when no `config.json` exists.
- Verified an existing `config.json` remains unchanged when both files exist.
- Verified normal config loading and application startup.
- Built macOS arm64, Linux x64, and Windows x64 packages.
