### PR TITLE
Allow 1080p video options on 1280x800 displays

### DIFF
--- a/src/preload/modules/h5vcc/index.js
+++ b/src/preload/modules/h5vcc/index.js
@@ -6,11 +6,12 @@ const config = configManager.get()
 
 function getMaxResolution() {
     let resolutions = [ '256x144', '426x240', '640x360', '854x480', '1280x720', '1920x1080', '2560x1440', '3840x2160', '7680x4320' ]
-    let screenSize = Math.max(window.screen.width, window.screen.height)
+    let screenWidth = Math.max(window.screen.width, window.screen.height)
+    let screenHeight = Math.min(window.screen.width, window.screen.height)
 
     for (let i = 0; i < resolutions.length; i++) {
-        let width = Number(resolutions[i].split('x')[0])
-        if (screenSize <= width) return resolutions[i];
+        let [ width, height ] = resolutions[i].split('x').map(Number)
+        if (screenWidth <= width && screenHeight <= height) return resolutions[i];
     }
 
     return `${window.screen.width}x${window.screen.height}`;


### PR DESCRIPTION
## Summary

Consider both display dimensions when selecting the maximum standard video resolution.

This lets 1280x800 displays such as the Steam Deck request 1080p streams while preserving the existing 720p limit for true 1280x720 displays.

## Root cause

The resolution selector compared only the display's longest dimension. Because the Steam Deck width is exactly 1280 pixels, it selected 1280x720 without checking that the display is 800 pixels tall.

## Testing

- Verified 1280x800 and 800x1280 select 1920x1080.
- Verified exact 1280x720, 1920x1080, and 2560x1440 displays keep their existing limits.
- Verified 1366x768, 1920x1200, and 2560x1600 select the first standard resolution covering both dimensions.
- Packaged macOS arm64, Linux x64, and Windows x64 builds.
- Verified the updated selector is present in each packaged ASAR.
