### PR TITLE
Fix issue #198

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,12 @@ the "compatible" and "VacuumTube" part are just for transparency's sake, and to 
 this is only used because you have to have a good user agent to be "allowed" onto leanback, and many innertube endpoints check the user agent specifically to know what to send (e.g. high quality thumbnails)
 VacuumTube overrides some things to identify properly, but this user agent has to be sent with every request to youtube sadly
 */
-const youtubeUserAgent = `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/26.lts.0-qa; compatible; VacuumTube/${package.version}` //for youtube, sent in innertube calls
-const youtubeClientUserAgent = `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/19.lts.0-qa; compatible; VacuumTube/${package.version}` //for youtube, somewhere in client scripts this matters because it parses cobalt version explicitly from the user agent, which affects playability because cobalt 26 "should" work with widevine, when we can't support that
+// Use the same Cobalt 19 user agent for both the Leanback client and
+// YouTube requests. Mixing Cobalt 26 requests with a Cobalt 19 client
+// causes playback to fail after roughly 45 seconds.
+const youtubeClientUserAgent =
+  `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/19.lts.0-qa; compatible; VacuumTube/${package.version}`
+const youtubeUserAgent = youtubeClientUserAgent
 const userAgent = `VacuumTube/${package.version}` //for anything else
 
 const youtubeUrl = 'https://www.youtube.com/tv'

--- a/src/index.js
+++ b/src/index.js
@@ -44,12 +44,11 @@ the "compatible" and "VacuumTube" part are just for transparency's sake, and to 
 this is only used because you have to have a good user agent to be "allowed" onto leanback, and many innertube endpoints check the user agent specifically to know what to send (e.g. high quality thumbnails)
 VacuumTube overrides some things to identify properly, but this user agent has to be sent with every request to youtube sadly
 */
-// Use the same Cobalt 19 user agent for both the Leanback client and
-// YouTube requests. Mixing Cobalt 26 requests with a Cobalt 19 client
-// causes playback to fail after roughly 45 seconds.
 const youtubeClientUserAgent =
   `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/19.lts.0-qa; compatible; VacuumTube/${package.version}`
-const youtubeUserAgent = youtubeClientUserAgent
+// Cobalt 25 appears to resolve issue #198 while preserving HQ thumbnails. 
+const youtubeUserAgent =
+  `Mozilla/5.0 (PS4; Leanback Shell) Cobalt/25.lts.40.1035033; compatible; VacuumTube/${package.version}`
 const userAgent = `VacuumTube/${package.version}` //for anything else
 
 const youtubeUrl = 'https://www.youtube.com/tv'


### PR DESCRIPTION
## Summary

Downgrades the YouTube request user agent from Cobalt 26 to Cobalt 25.

This resolves playback failures occurring roughly 45 seconds into videos while preserving higher-resolution thumbnails and newer Innertube responses.

Fixes #198.

## Root Cause

YouTube's current responses for the Cobalt 26 request profile appear to cause playback to fail in VacuumTube.

The exact upstream incompatibility is unknown. Cobalt 19 resolves playback but reduces thumbnail resolution, while Cobalt 25 resolves playback and continues returning higher-quality thumbnails.

## Validation

Tested:

- Regular video playback beyond the previous failure point
- Seeking and autoplay
- Live streams
- Signed-in playback with multiple accounts
- 1440p60 HDR playback
- Cobalt 19 client-side UA remains unchanged
- Innertube requests verified as using Cobalt 25
- Matching thumbnails improved from 320×180 with Cobalt 19 to 640×360 with Cobalt 25
- Tested across two Windows PCs and different network conditions

No regressions observed in playback, Leanback navigation, or account functionality.