### PR TITLE
Feature: Add About page to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Otherwise, you can use a distribution package or a portable one. If you don't kn
 
 VacuumTube has some settings that you can change, which are located directly in the YouTube settings. They can also be opened by pressing `Ctrl+O` on your keyboard or `R3` on your controller.
 
+- About
+  - Shows the installed version, platform, installation type, and update method
+  - Checks for new releases and links to the appropriate update source when an in-app update is unavailable
+  - Includes direct links to the project and its latest releases
 - Ad Block
   - Seamlessly blocks video and feed ads, not subject to YouTube's methods of preventing blockers
 - SponsorBlock
@@ -186,6 +190,9 @@ npm i
 
 # Run without packaging
 npm run start
+
+# Run the automated tests
+npm test
 
 # Or package builds for your operating system
 npm run windows:build

--- a/locale/en.json
+++ b/locale/en.json
@@ -139,6 +139,76 @@
                 "unknown": "Unknown",
                 "unsupported": "Unsupported"
             }
+        },
+        "about": {
+            "title": "About",
+            "description": "YouTube for TV on your desktop, with controller support and thoughtful enhancements.",
+            "version": "Version {version}",
+            "platform_label": "Platform",
+            "installation_label": "Installation",
+            "update_method_label": "Update method",
+            "view_github": "View on GitHub",
+            "latest_releases": "Latest releases",
+            "platforms": {
+                "darwin": "macOS",
+                "win32": "Windows",
+                "linux": "Linux"
+            },
+            "architectures": {
+                "apple_silicon": "Apple silicon",
+                "arm64": "ARM64",
+                "x64": "x64",
+                "ia32": "x86"
+            },
+            "installations": {
+                "application": "Application",
+                "installer": "Installed application",
+                "portable": "Portable application",
+                "flatpak": "Flatpak",
+                "appimage": "AppImage",
+                "package": "System package",
+                "development": "Development build",
+                "unknown": "Unknown"
+            },
+            "update_methods": {
+                "automatic": "Automatic installer",
+                "manual": "Manual download",
+                "flatpak": "Flatpak"
+            },
+            "updates": {
+                "idle_title": "Updates",
+                "idle_detail": "Check whether a newer version of VacuumTube is available.",
+                "check_now": "Check for updates",
+                "checking_title": "Checking for updates…",
+                "checking_detail": "Looking for the newest VacuumTube release.",
+                "checking_button": "Checking…",
+                "current_title": "You’re up to date",
+                "current_detail": "VacuumTube {version} is the newest version available.",
+                "checked_badge": "Checked just now",
+                "check_again": "Check again",
+                "available_title": "VacuumTube {version} is available",
+                "available_automatic_detail": "Download the update now, then restart VacuumTube when it is ready.",
+                "available_manual_detail": "Download the latest build and replace your current copy.",
+                "current_badge": "Current version: {version}",
+                "download_update": "Download update",
+                "download_latest": "Download latest version",
+                "downloading_title": "Downloading update…",
+                "downloading_detail": "The update is {percent}% downloaded.",
+                "downloading_button": "Downloading… {percent}%",
+                "ready_title": "Update ready to install",
+                "ready_detail": "Restart VacuumTube to install version {version}.",
+                "ready_badge": "Download complete",
+                "install_update": "Restart and install",
+                "error_title": "Couldn’t check for updates",
+                "error_detail": "Check your connection and try again, or open the releases page.",
+                "try_again": "Try again",
+                "development_title": "Development build",
+                "development_detail": "Automatic update checks are available in packaged builds.",
+                "unsupported_title": "Update check unavailable",
+                "unsupported_detail": "Use the update method shown below to check for a newer version.",
+                "view_update_source": "View update source",
+                "view_releases": "View latest releases"
+            }
         }
     },
     "sponsorblock": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "src/index.js",
     "scripts": {
         "start": "electron .",
+        "test": "node --test",
         "windows:build": "electron-builder --win",
         "mac:build": "electron-builder --mac",
         "linux:build": "electron-builder --linux",

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ electron.app.setPath('sessionData', sessionData)
 
 const configManager = require('./config.js')
 const permissions = require('./permissions.js')
+const updater = require('./updater.js')
 const userstyles = require('./userstyles.js')
 
 //code
@@ -126,7 +127,7 @@ async function main() {
 
     await electron.app.whenReady()
 
-    autoUpdater.checkForUpdatesAndNotify()
+    updater.setup({ electron, autoUpdater, getWindow: () => win })
     permissions.setup({ appId })
 
     //general request modification
@@ -194,7 +195,7 @@ async function main() {
                 let imgMatch = header.match(imgPattern)
                 if (imgMatch) {
                     let existing = imgMatch[1]
-                    let additions = 'dearrow-thumb.ajay.app'
+                    let additions = 'dearrow-thumb.ajay.app data:'
                     let updated = `img-src ${existing} ${additions}`
                     header = header.replace(imgPattern, updated)
                 }

--- a/src/preload/modules/settings/index.js
+++ b/src/preload/modules/settings/index.js
@@ -61,7 +61,8 @@ let tabs = [
     { id: 'touch_overlay' },
     { id: 'controller_support' },
     { id: 'device_discoverability' },
-    { id: 'mac_permissions', hide: process.platform !== 'darwin' }
+    { id: 'mac_permissions', hide: process.platform !== 'darwin' },
+    { id: 'about' }
 ]
 
 tabs = tabs.filter(t => !t.hide)
@@ -76,6 +77,7 @@ for (let item of tabs) {
 //custom panels (settings with their own interface instead of a single toggle), keyed by tab id
 const panelModules = [
     require('./panels/features'),
+    require('./panels/about'),
     require('./panels/h264ify'),
     require('./panels/mac-permissions'),
     require('./panels/userstyles')

--- a/src/preload/modules/settings/panels/about.js
+++ b/src/preload/modules/settings/panels/about.js
@@ -1,0 +1,241 @@
+const fs = require('fs')
+const path = require('path')
+const { ipcRenderer } = require('electron')
+const { el } = require('../dom')
+
+const iconPath = path.join(__dirname, '../../../../../assets/icon.png')
+const iconDataUrl = `data:image/png;base64,${fs.readFileSync(iconPath).toString('base64')}`
+
+let locale = null;
+let updateState = {
+    status: 'idle',
+    currentVersion: '',
+    latestVersion: '',
+    platform: process.platform,
+    arch: process.arch,
+    installationType: 'unknown',
+    canAutoUpdate: false,
+    progress: null
+}
+
+function interpolate(template, values = {}) {
+    let result = template;
+    for (const [ key, value ] of Object.entries(values)) {
+        result = result.replaceAll(`{${key}}`, String(value))
+    }
+    return result;
+}
+
+function platformLabel() {
+    const platforms = locale.settings.about.platforms
+    const architectures = locale.settings.about.architectures
+    const platform = platforms[updateState.platform] || updateState.platform;
+    const architectureKey = updateState.platform === 'darwin' && updateState.arch === 'arm64'
+        ? 'apple_silicon'
+        : updateState.arch;
+    const arch = architectures[architectureKey] || updateState.arch;
+    return `${platform} · ${arch}`;
+}
+
+function installationLabel() {
+    return locale.settings.about.installations[updateState.installationType]
+        || locale.settings.about.installations.unknown;
+}
+
+function updateMethodLabel() {
+    if (updateState.canAutoUpdate) return locale.settings.about.update_methods.automatic;
+    if (updateState.installationType === 'flatpak') return locale.settings.about.update_methods.flatpak;
+    return locale.settings.about.update_methods.manual;
+}
+
+function statusContent() {
+    const text = locale.settings.about.updates;
+    const currentVersion = updateState.currentVersion;
+    const latestVersion = updateState.latestVersion || currentVersion;
+
+    switch (updateState.status) {
+        case 'checking':
+            return { title: text.checking_title, detail: text.checking_detail, badge: '', button: text.checking_button, tone: 'neutral' };
+        case 'current':
+            return {
+                title: text.current_title,
+                detail: interpolate(text.current_detail, { version: currentVersion }),
+                badge: text.checked_badge,
+                button: text.check_again,
+                tone: 'success'
+            };
+        case 'available':
+            return {
+                title: interpolate(text.available_title, { version: latestVersion }),
+                detail: updateState.canAutoUpdate ? text.available_automatic_detail : text.available_manual_detail,
+                badge: interpolate(text.current_badge, { version: currentVersion }),
+                button: updateState.canAutoUpdate ? text.download_update : text.download_latest,
+                tone: 'warning'
+            };
+        case 'downloading':
+            return {
+                title: text.downloading_title,
+                detail: interpolate(text.downloading_detail, { percent: updateState.progress ?? 0 }),
+                badge: interpolate(text.current_badge, { version: currentVersion }),
+                button: interpolate(text.downloading_button, { percent: updateState.progress ?? 0 }),
+                tone: 'neutral'
+            };
+        case 'ready':
+            return {
+                title: text.ready_title,
+                detail: interpolate(text.ready_detail, { version: latestVersion }),
+                badge: text.ready_badge,
+                button: text.install_update,
+                tone: 'warning'
+            };
+        case 'error':
+            return { title: text.error_title, detail: text.error_detail, badge: '', button: text.try_again, tone: 'error' };
+        case 'development':
+            return { title: text.development_title, detail: text.development_detail, badge: '', button: text.view_releases, tone: 'neutral' };
+        case 'unsupported':
+            return { title: text.unsupported_title, detail: text.unsupported_detail, badge: '', button: text.view_update_source, tone: 'neutral' };
+        default:
+            return { title: text.idle_title, detail: text.idle_detail, badge: '', button: text.check_now, tone: 'neutral' };
+    }
+}
+
+function setText(id, text) {
+    const node = document.getElementById(id)
+    if (node) node.textContent = text;
+}
+
+function renderState() {
+    setText('vt-about-version', interpolate(locale.settings.about.version, { version: updateState.currentVersion }))
+    setText('vt-about-platform', platformLabel())
+    setText('vt-about-installation', installationLabel())
+    setText('vt-about-update-method', updateMethodLabel())
+
+    const content = statusContent()
+    setText('vt-about-update-title', content.title)
+    setText('vt-about-update-detail', content.detail)
+    setText('vt-about-update-button', content.button)
+
+    const badge = document.getElementById('vt-about-update-status')
+    if (badge) {
+        badge.textContent = content.badge;
+        badge.hidden = !content.badge;
+        badge.dataset.tone = content.tone;
+    }
+
+    const button = document.querySelector('.vt-button[data-action="primary-update-action"]')
+    if (button) {
+        const busy = updateState.status === 'checking' || updateState.status === 'downloading'
+        button.classList.toggle('vt-button-inactive', busy)
+        button.setAttribute('aria-disabled', String(busy))
+    }
+}
+
+async function refresh() {
+    try {
+        updateState = await ipcRenderer.invoke('get-about-info')
+        renderState()
+    } catch (err) {
+        console.error('[About] Failed to load application information:', err)
+        updateState = { ...updateState, status: 'error' }
+        renderState()
+    }
+}
+
+async function runPrimaryUpdateAction() {
+    switch (updateState.status) {
+        case 'checking':
+        case 'downloading':
+            return;
+        case 'available':
+            if (updateState.canAutoUpdate) {
+                await ipcRenderer.invoke('download-update')
+            } else {
+                await ipcRenderer.invoke('open-update-download')
+            }
+            return;
+        case 'ready':
+            await ipcRenderer.invoke('install-update')
+            return;
+        case 'development':
+            await ipcRenderer.invoke('open-release-page')
+            return;
+        case 'unsupported':
+            await ipcRenderer.invoke('open-update-download')
+            return;
+        default:
+            updateState = await ipcRenderer.invoke('check-for-updates')
+            renderState()
+    }
+}
+
+module.exports = {
+    id: 'about',
+
+    init(ctx) {
+        locale = ctx.locale;
+    },
+
+    render() {
+        const text = locale.settings.about;
+
+        return el('div', { className: 'vt-about-section' }, [
+            el('div', { className: 'vt-about-heading' }, [
+                el('img', { className: 'vt-about-icon', src: iconDataUrl, alt: '' }),
+                el('div', { className: 'vt-about-copy' }, [
+                    el('span', { className: 'vt-about-name', textContent: 'VacuumTube' }),
+                    el('span', { className: 'vt-about-description', textContent: text.description })
+                ]),
+                el('span', { className: 'vt-about-version', id: 'vt-about-version' })
+            ]),
+            el('div', { className: 'vt-about-update-card' }, [
+                el('div', { className: 'vt-about-update-copy' }, [
+                    el('span', { className: 'vt-about-update-title', id: 'vt-about-update-title' }),
+                    el('span', { className: 'vt-about-update-detail', id: 'vt-about-update-detail' }),
+                    el('span', { className: 'vt-about-update-status', id: 'vt-about-update-status', hidden: true })
+                ]),
+                el('div', { className: 'vt-button', dataAction: 'primary-update-action', dataIndex: '0' }, [
+                    el('span', { id: 'vt-about-update-button' })
+                ])
+            ]),
+            el('div', { className: 'vt-about-details' }, [
+                el('div', { className: 'vt-about-detail' }, [
+                    el('span', { className: 'vt-about-detail-label', textContent: text.platform_label }),
+                    el('span', { className: 'vt-about-detail-value', id: 'vt-about-platform' })
+                ]),
+                el('div', { className: 'vt-about-detail' }, [
+                    el('span', { className: 'vt-about-detail-label', textContent: text.installation_label }),
+                    el('span', { className: 'vt-about-detail-value', id: 'vt-about-installation' })
+                ]),
+                el('div', { className: 'vt-about-detail' }, [
+                    el('span', { className: 'vt-about-detail-label', textContent: text.update_method_label }),
+                    el('span', { className: 'vt-about-detail-value', id: 'vt-about-update-method' })
+                ])
+            ]),
+            el('div', { className: 'vt-about-links' }, [
+                el('div', { className: 'vt-button vt-about-primary-button', dataAction: 'open-project-page', dataIndex: '1' }, [
+                    el('span', { textContent: text.view_github })
+                ]),
+                el('div', { className: 'vt-button', dataAction: 'open-release-page', dataIndex: '2' }, [
+                    el('span', { textContent: text.latest_releases })
+                ])
+            ])
+        ]);
+    },
+
+    setup() {
+        ipcRenderer.on('update-state-changed', (event, nextState) => {
+            updateState = nextState;
+            renderState()
+        })
+    },
+
+    onShow() {
+        refresh()
+    },
+
+    actions: {
+        'primary-update-action': runPrimaryUpdateAction,
+        'open-project-page': () => ipcRenderer.invoke('open-project-page'),
+        'open-release-page': () => ipcRenderer.invoke('open-release-page')
+    }
+}

--- a/src/preload/modules/settings/style.css
+++ b/src/preload/modules/settings/style.css
@@ -557,3 +557,154 @@
     outline: 2px solid #fff;
     outline-offset: -2px;
 }
+
+.vt-about-section {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    gap: 10px;
+}
+
+.vt-about-heading {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    min-height: 64px;
+}
+
+.vt-about-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 14px;
+    flex-shrink: 0;
+}
+
+.vt-about-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.vt-about-name {
+    color: #fff;
+    font-size: 26px;
+    font-weight: 500;
+    margin-bottom: 6px;
+}
+
+.vt-about-description,
+.vt-about-update-detail {
+    color: #aaa;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.vt-about-version {
+    align-self: flex-start;
+    margin-left: auto;
+    padding: 7px 11px;
+    background: #333;
+    border-radius: 7px;
+    color: #fff;
+    font-size: 14px;
+    white-space: nowrap;
+}
+
+.vt-about-update-card {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 14px 18px;
+    background: #2a2a2a;
+    border-radius: 12px;
+}
+
+.vt-about-update-copy {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.vt-about-update-title {
+    color: #fff;
+    font-size: 19px;
+    font-weight: 500;
+    margin-bottom: 7px;
+}
+
+.vt-about-update-status {
+    width: fit-content;
+    margin-top: 10px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: #3a3a3a;
+    color: #fff;
+    font-size: 13px;
+}
+
+.vt-about-update-status[data-tone="success"] {
+    background: #1f5f3a;
+    color: #9ee0b5;
+}
+
+.vt-about-update-status[data-tone="warning"] {
+    background: #5c421f;
+    color: #ffc777;
+}
+
+.vt-about-update-status[data-tone="error"] {
+    background: #703030;
+    color: #ffb4b4;
+}
+
+.vt-about-update-card .vt-button {
+    min-width: 185px;
+}
+
+.vt-about-details {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.vt-about-detail {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    padding: 13px 15px;
+    background: #2a2a2a;
+    border-radius: 8px;
+}
+
+.vt-about-detail-label {
+    color: #aaa;
+    font-size: 12px;
+    margin-bottom: 5px;
+}
+
+.vt-about-detail-value {
+    color: #fff;
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vt-about-links {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-top: auto;
+}
+
+.vt-about-primary-button {
+    background: #fff;
+    color: #212121;
+}
+
+.vt-button.vt-button-inactive {
+    cursor: default;
+    opacity: 0.55;
+}

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,0 +1,201 @@
+const fs = require('fs')
+const path = require('path')
+
+const PROJECT_URL = 'https://github.com/shy1132/VacuumTube'
+const RELEASES_URL = `${PROJECT_URL}/releases/latest`
+const FLATPAK_URL = 'https://flathub.org/apps/rocks.shy.VacuumTube'
+
+let app;
+let autoUpdater;
+let getWindow;
+let installation;
+let shell;
+let initialized = false;
+
+let state = {
+    status: 'idle',
+    currentVersion: null,
+    latestVersion: null,
+    platform: process.platform,
+    arch: process.arch,
+    installationType: 'unknown',
+    canAutoUpdate: false,
+    progress: null
+}
+
+function detectInstallation({
+    platform = process.platform,
+    exePath = process.execPath,
+    isPackaged = false,
+    env = process.env,
+    existsSync = fs.existsSync
+} = {}) {
+    if (!isPackaged) return { type: 'development', canAutoUpdate: false };
+
+    if (platform === 'darwin') {
+        return { type: 'application', canAutoUpdate: false };
+    }
+
+    if (platform === 'win32') {
+        const uninstaller = path.win32.join(path.win32.dirname(exePath), 'Uninstall VacuumTube.exe')
+        const installed = existsSync(uninstaller)
+        return {
+            type: installed ? 'installer' : 'portable',
+            canAutoUpdate: installed
+        };
+    }
+
+    if (env.FLATPAK_ID || existsSync('/.flatpak-info')) {
+        return { type: 'flatpak', canAutoUpdate: false };
+    }
+
+    if (env.APPIMAGE) {
+        return { type: 'appimage', canAutoUpdate: false };
+    }
+
+    return { type: 'package', canAutoUpdate: false };
+}
+
+function getManualDownloadUrl(platform = process.platform, arch = process.arch, installationType = 'unknown') {
+    if (installationType === 'flatpak') return FLATPAK_URL;
+
+    if (platform === 'darwin') {
+        return `${RELEASES_URL}/download/VacuumTube-universal.dmg`;
+    }
+
+    if (platform === 'win32') {
+        const windowsArch = arch === 'arm64' ? 'arm64' : 'x64'
+        return `${RELEASES_URL}/download/VacuumTube-${windowsArch}-Portable.zip`;
+    }
+
+    return RELEASES_URL;
+}
+
+function snapshot() {
+    return { ...state };
+}
+
+function publish(patch) {
+    state = { ...state, ...patch }
+
+    const win = getWindow?.()
+    if (win && !win.isDestroyed()) {
+        win.webContents.send('update-state-changed', snapshot())
+    }
+}
+
+async function checkForUpdates() {
+    if (!app.isPackaged) {
+        publish({ status: 'development', progress: null })
+        return snapshot();
+    }
+
+    if (installation.type === 'flatpak') {
+        publish({ status: 'unsupported', progress: null })
+        return snapshot();
+    }
+
+    publish({ status: 'checking', progress: null })
+
+    try {
+        const result = await autoUpdater.checkForUpdates()
+        if (!result) publish({ status: 'unsupported' })
+    } catch (err) {
+        console.error('[Updater] Failed to check for updates:', err)
+        publish({ status: 'error', progress: null })
+    }
+
+    return snapshot();
+}
+
+async function downloadUpdate() {
+    if (!installation.canAutoUpdate || state.status !== 'available') return snapshot();
+
+    publish({ status: 'downloading', progress: 0 })
+
+    try {
+        await autoUpdater.downloadUpdate()
+    } catch (err) {
+        console.error('[Updater] Failed to download update:', err)
+        publish({ status: 'error', progress: null })
+    }
+
+    return snapshot();
+}
+
+function installUpdate() {
+    if (!installation.canAutoUpdate || state.status !== 'ready') return false;
+
+    autoUpdater.quitAndInstall(false, true)
+    return true;
+}
+
+async function openExternal(url) {
+    await shell.openExternal(url)
+    return true;
+}
+
+function setup(options) {
+    if (initialized) return;
+
+    app = options.electron.app;
+    autoUpdater = options.autoUpdater;
+    getWindow = options.getWindow;
+    shell = options.electron.shell;
+    installation = detectInstallation({
+        platform: process.platform,
+        exePath: app.getPath('exe'),
+        isPackaged: app.isPackaged
+    })
+
+    state = {
+        ...state,
+        currentVersion: app.getVersion(),
+        installationType: installation.type,
+        canAutoUpdate: installation.canAutoUpdate
+    }
+
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = false;
+
+    autoUpdater.on('checking-for-update', () => publish({ status: 'checking', progress: null }))
+    autoUpdater.on('update-not-available', (info) => publish({
+        status: 'current',
+        latestVersion: info?.version || state.currentVersion,
+        progress: null
+    }))
+    autoUpdater.on('update-available', (info) => publish({
+        status: 'available',
+        latestVersion: info?.version || null,
+        progress: null
+    }))
+    autoUpdater.on('download-progress', (progress) => publish({
+        status: 'downloading',
+        progress: Math.round(progress.percent)
+    }))
+    autoUpdater.on('update-downloaded', (info) => publish({
+        status: 'ready',
+        latestVersion: info?.version || state.latestVersion,
+        progress: 100
+    }))
+    autoUpdater.on('error', () => publish({ status: 'error', progress: null }))
+
+    options.electron.ipcMain.handle('get-about-info', () => snapshot())
+    options.electron.ipcMain.handle('check-for-updates', () => checkForUpdates())
+    options.electron.ipcMain.handle('download-update', () => downloadUpdate())
+    options.electron.ipcMain.handle('install-update', () => installUpdate())
+    options.electron.ipcMain.handle('open-project-page', () => openExternal(PROJECT_URL))
+    options.electron.ipcMain.handle('open-release-page', () => openExternal(RELEASES_URL))
+    options.electron.ipcMain.handle('open-update-download', () => openExternal(
+        getManualDownloadUrl(state.platform, state.arch, state.installationType)
+    ))
+
+    initialized = true;
+    void checkForUpdates()
+}
+
+module.exports = {
+    setup,
+    detectInstallation,
+    getManualDownloadUrl
+}

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -1,0 +1,155 @@
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+const test = require('node:test')
+const package = require('../package.json')
+const { detectInstallation, getManualDownloadUrl } = require('../src/updater')
+
+function createUpdaterHarness(checkForUpdates) {
+    const modulePath = require.resolve('../src/updater')
+    delete require.cache[modulePath]
+    const updater = require(modulePath)
+    const handlers = new Map()
+    const openedUrls = []
+    const autoUpdater = new EventEmitter()
+
+    autoUpdater.checkForUpdates = checkForUpdates.bind(null, autoUpdater)
+    autoUpdater.downloadUpdate = async () => {}
+    autoUpdater.quitAndInstall = () => {}
+
+    updater.setup({
+        autoUpdater,
+        getWindow: () => null,
+        electron: {
+            app: {
+                isPackaged: true,
+                getPath: () => '/Applications/VacuumTube.app/Contents/MacOS/VacuumTube',
+                getVersion: () => package.version
+            },
+            ipcMain: {
+                handle: (name, handler) => handlers.set(name, handler)
+            },
+            shell: {
+                openExternal: async (url) => openedUrls.push(url)
+            }
+        }
+    })
+
+    return { autoUpdater, handlers, openedUrls }
+}
+
+test('development builds do not offer automatic updates', () => {
+    assert.deepEqual(detectInstallation({ isPackaged: false }), {
+        type: 'development',
+        canAutoUpdate: false
+    })
+})
+
+test('macOS applications use manual downloads while releases are unsigned', () => {
+    assert.deepEqual(detectInstallation({ platform: 'darwin', isPackaged: true }), {
+        type: 'application',
+        canAutoUpdate: false
+    })
+})
+
+test('Windows only enables automatic updates for a detected installer copy', () => {
+    const exePath = 'C:\\Users\\Test\\VacuumTube\\VacuumTube.exe'
+
+    assert.deepEqual(detectInstallation({
+        platform: 'win32',
+        exePath,
+        isPackaged: true,
+        existsSync: (candidate) => candidate === 'C:\\Users\\Test\\VacuumTube\\Uninstall VacuumTube.exe'
+    }), {
+        type: 'installer',
+        canAutoUpdate: true
+    })
+
+    assert.deepEqual(detectInstallation({
+        platform: 'win32',
+        exePath,
+        isPackaged: true,
+        existsSync: () => false
+    }), {
+        type: 'portable',
+        canAutoUpdate: false
+    })
+})
+
+test('Linux recognizes Flatpak and AppImage packaging without guessing package managers', () => {
+    assert.deepEqual(detectInstallation({
+        platform: 'linux',
+        isPackaged: true,
+        env: { FLATPAK_ID: 'rocks.shy.VacuumTube' },
+        existsSync: () => false
+    }), {
+        type: 'flatpak',
+        canAutoUpdate: false
+    })
+
+    assert.deepEqual(detectInstallation({
+        platform: 'linux',
+        isPackaged: true,
+        env: { APPIMAGE: '/tmp/VacuumTube.AppImage' },
+        existsSync: () => false
+    }), {
+        type: 'appimage',
+        canAutoUpdate: false
+    })
+})
+
+test('manual download links select stable platform artifacts', () => {
+    assert.match(getManualDownloadUrl('darwin', 'arm64'), /VacuumTube-universal\.dmg$/)
+    assert.match(getManualDownloadUrl('win32', 'arm64'), /VacuumTube-arm64-Portable\.zip$/)
+    assert.match(getManualDownloadUrl('win32', 'x64'), /VacuumTube-x64-Portable\.zip$/)
+    assert.match(getManualDownloadUrl('linux', 'x64'), /\/releases\/latest$/)
+    assert.match(getManualDownloadUrl('linux', 'x64', 'flatpak'), /flathub\.org\/apps\/rocks\.shy\.VacuumTube$/)
+})
+
+test('packaged update checks publish the current version and open an allowlisted download', async () => {
+    const harness = createUpdaterHarness(async (autoUpdater) => {
+        autoUpdater.emit('update-not-available', { version: package.version })
+        return {}
+    })
+
+    await new Promise(setImmediate)
+
+    const installationType = process.platform === 'darwin'
+        ? 'application'
+        : process.platform === 'win32'
+            ? 'portable'
+            : 'package';
+
+    assert.deepEqual(await harness.handlers.get('get-about-info')(), {
+        status: 'current',
+        currentVersion: package.version,
+        latestVersion: package.version,
+        platform: process.platform,
+        arch: process.arch,
+        installationType,
+        canAutoUpdate: false,
+        progress: null
+    })
+
+    await harness.handlers.get('open-update-download')()
+    assert.deepEqual(harness.openedUrls, [
+        getManualDownloadUrl(process.platform, process.arch, installationType)
+    ])
+})
+
+test('failed update checks expose a retryable error state', async () => {
+    const originalConsoleError = console.error
+    console.error = () => {}
+
+    try {
+        const harness = createUpdaterHarness(async () => {
+            throw new Error('offline')
+        })
+
+        await new Promise(setImmediate)
+
+        assert.equal((await harness.handlers.get('get-about-info')()).status, 'error')
+        assert.equal((await harness.handlers.get('check-for-updates')()).status, 'error')
+    } finally {
+        console.error = originalConsoleError
+    }
+})


### PR DESCRIPTION
Someone requested an About page outside of GitHub, and I thought it wasn't a bad idea.

This adds an About section to VacuumTube settings with:

- The installed app version and platform
- The detected installation and update method
- A clearer update check with current, available, downloading, ready, and error states
- Automatic update handling for supported installed copies
- Appropriate manual update links for other installation types
- Direct links to the project and latest releases

The displayed version comes directly from Electron's application version, which is already sourced from `package.json`. This does not add another version number or change the existing version-bump and release process.

## Testing

- `npm test` — 7 updater tests passing
- JavaScript syntax, locale JSON, locale fallback, and diff checks
- Keyboard/controller navigation at the default 1200×675 window size
- macOS arm64 DMG build and packaged startup
- Live update check from the packaged app against the current release

Windows and Linux packaged update flows were not validated locally.
