### PR TITLE
Add background receiver mode for desktop and HTPC systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,36 @@ VacuumTube has some settings that you can change, which are located directly in 
 - Device Discoverability
   - Allows VacuumTube to be discovered by the YouTube mobile app on devices within the same local network (DIAL)
 
+## Background Receiver Mode
+
+VacuumTube can also act as an on-demand software TV receiver on a regular desktop computer, HTPC, Raspberry Pi OS system, Steam Deck in desktop mode, or another device with a full operating system.
+
+This is useful when the device is not a dedicated TV box: you can keep using the desktop normally, then select VacuumTube from the **Cast** menu in the YouTube mobile app whenever you want to watch something on the larger screen.
+
+Start VacuumTube with:
+
+```sh
+vacuumtube --background-receiver --fullscreen
+```
+
+For Flatpak installations:
+
+```sh
+flatpak run rocks.shy.VacuumTube --background-receiver --fullscreen
+```
+
+In this mode:
+
+1. VacuumTube starts hidden instead of occupying the screen.
+2. It remains discoverable through DIAL while running in the background.
+3. A successful Cast launch restores the window automatically. `--fullscreen` makes it open as a TV-style fullscreen player.
+4. You can minimize the window after watching and continue using the computer; VacuumTube stays available for another Cast request.
+5. Closing the window exits VacuumTube normally.
+
+You can add the same command to your desktop environment's startup applications to make the receiver available after login. If YouTube TV cannot load during startup, the error page stays hidden instead of covering the desktop.
+
+**Device Discoverability** must be enabled for casting from the YouTube mobile app.
+
 ## Extra Input Mappings
 
 VacuumTube exposes a few extra input mappings for actions that may be desired on a desktop:
@@ -144,6 +174,8 @@ The userstyles folder is located in the config folder mentioned below.
   - Operates VacuumTube in portable mode, setting data directory to the one you specify, or defaulting to `data` in the executable directory (you can also create `portable.txt` in the executable directory, which works in the same way)
 - `--fullscreen`
   - Forces VacuumTube to open in fullscreen
+- `--background-receiver`
+  - Starts VacuumTube hidden and restores the window automatically when a successful DIAL Cast launch is received. Intended for desktop and HTPC systems that should remain usable while VacuumTube waits in the background
 - `--no-window-decorations`
   - Opens VacuumTube with hidden window decorations
 - `enable-devtools`

--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ In this mode:
 2. It remains discoverable through DIAL while running in the background.
 3. A successful Cast launch restores the window automatically. `--fullscreen` makes it open as a TV-style fullscreen player.
 4. You can minimize the window after watching and continue using the computer; VacuumTube stays available for another Cast request.
-5. Closing the window exits VacuumTube normally.
+5. Launching VacuumTube again focuses the already running receiver instead of starting a second copy.
+6. After sleep/resume or reconnecting to the network, the receiver refreshes its DIAL address and discovery socket.
+7. Closing the window exits VacuumTube normally.
 
-You can add the same command to your desktop environment's startup applications to make the receiver available after login. If YouTube TV cannot load during startup, the error page stays hidden instead of covering the desktop.
+You can add the same command to your desktop environment's startup applications to make the receiver available after login. VacuumTube only stays hidden after DIAL reports that it is ready; if Device Discoverability is disabled, DIAL fails, or the receiver is not ready within 15 seconds, the normal window is shown instead of leaving the application stuck invisibly in the background.
 
 **Device Discoverability** must be enabled for casting from the YouTube mobile app.
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,16 @@ if (portablePath) {
 const sessionData = path.join(userData, 'sessionData')
 electron.app.setPath('sessionData', sessionData)
 
+const gotSingleInstanceLock = electron.app.requestSingleInstanceLock()
+if (!gotSingleInstanceLock) {
+    electron.app.quit()
+} else {
+    electron.app.on('second-instance', () => {
+        console.log('[app] Second instance requested; showing the existing window')
+        showReceiverWindow()
+    })
+}
+
 const configManager = require('./config.js')
 const permissions = require('./permissions.js')
 const userstyles = require('./userstyles.js')
@@ -53,21 +63,48 @@ const runningOnSteam = process.env.SteamOS === '1' && process.env.SteamGamepadUI
 
 let win;
 let config;
+let dialReady = false;
+let dialStartupTimeout = null;
 
-const backgroundReceiver = !!argv['background-receiver'];
+const backgroundReceiver = argv['background-receiver'] === true || argv['background-receiver'] === 'true';
+const dialStartupTimeoutMs = 15000;
 
 function getRequestedFullscreen() {
-    return argv['fullscreen'] || runningOnSteam || config.fullscreen || false;
+    return argv['fullscreen'] || runningOnSteam || config?.fullscreen || false;
+}
+
+function clearDialStartupTimeout() {
+    if (!dialStartupTimeout) return;
+
+    clearTimeout(dialStartupTimeout)
+    dialStartupTimeout = null;
 }
 
 function showReceiverWindow() {
     if (!win || win.isDestroyed()) return;
 
+    clearDialStartupTimeout()
     win.setSkipTaskbar(false)
     if (win.isMinimized()) win.restore()
     win.show()
     win.setFullScreen(getRequestedFullscreen())
     win.focus()
+}
+
+function waitForDialOrShowWindow() {
+    if (!backgroundReceiver || dialReady) return;
+
+    if (!config.device_discoverability) {
+        console.warn('[background-receiver] Device Discoverability is disabled; showing VacuumTube normally')
+        showReceiverWindow()
+        return;
+    }
+
+    clearDialStartupTimeout()
+    dialStartupTimeout = setTimeout(() => {
+        console.warn('[background-receiver] DIAL did not become ready in time; showing VacuumTube normally')
+        showReceiverWindow()
+    }, dialStartupTimeoutMs)
 }
 
 async function main() {
@@ -253,8 +290,31 @@ async function main() {
         event.returnValue = config;
     })
 
-    electron.ipcMain.on('dial-launch-request', () => {
-        if (backgroundReceiver) showReceiverWindow()
+    electron.ipcMain.on('dial-status', (event, status) => {
+        if (!backgroundReceiver || !win || event.sender !== win.webContents) return;
+
+        if (status === 'ready') {
+            dialReady = true;
+            clearDialStartupTimeout()
+            console.log('[background-receiver] DIAL receiver is ready')
+        } else if (status === 'disabled' || status === 'failed') {
+            dialReady = false;
+            console.warn(`[background-receiver] DIAL receiver is ${status}; showing VacuumTube normally`)
+            showReceiverWindow()
+        }
+    })
+
+    electron.ipcMain.on('dial-launch-succeeded', (event) => {
+        if (!backgroundReceiver || !dialReady || !win || event.sender !== win.webContents) return;
+        showReceiverWindow()
+    })
+
+    electron.powerMonitor.on('resume', () => {
+        if (!backgroundReceiver || !win || win.isDestroyed()) return;
+
+        dialReady = false;
+        win.webContents.send('dial-refresh')
+        waitForDialOrShowWindow()
     })
 
     //etc helpers
@@ -322,11 +382,9 @@ async function createWindow() {
     const initialFullscreen = backgroundReceiver ? false : fullscreen;
     let noWindowDecs = argv['no-window-decorations'] || config.no_window_decorations || false;
 
-    win = new electron.BrowserWindow({
+    let windowOptions = {
         width: 1200,
         height: 675,
-        show: false,
-        skipTaskbar: backgroundReceiver,
         backgroundColor: '#282828',
         fullscreen: initialFullscreen, //this sometimes doesn't work for people, so it's repeated below
         fullscreenable: true, //explicitly enable fullscreen functionality on macOS
@@ -334,7 +392,6 @@ async function createWindow() {
         frame: noWindowDecs ? false : true,
         icon: './assets/icon.png',
         webPreferences: {
-            backgroundThrottling: !backgroundReceiver,
             nodeIntegration: false,
             contextIsolation: false,
             sandbox: false, //allows me to use node apis in preload, but doesn't allow youtube to do so (solely need node apis for requiring the modules)
@@ -342,9 +399,24 @@ async function createWindow() {
             preload: path.join(__dirname, 'preload/index.js')
         },
         title: 'VacuumTube'
-    })
+    }
+
+    if (backgroundReceiver) {
+        windowOptions.show = false;
+        windowOptions.skipTaskbar = true;
+
+        // The hidden renderer hosts DIAL. Wayland is aggressive about throttling
+        // hidden surfaces, so keep it active there without changing other platforms.
+        if (process.platform === 'linux' && process.env.WAYLAND_DISPLAY) {
+            windowOptions.webPreferences.backgroundThrottling = false;
+        }
+    }
+
+    win = new electron.BrowserWindow(windowOptions)
 
     win.on('closed', () => {
+        clearDialStartupTimeout()
+        dialReady = false;
         win = null;
     })
 
@@ -407,6 +479,7 @@ async function createWindow() {
 
     console.log(`Loading ${youtubeUrl}`)
     win.loadURL(youtubeUrl, { userAgent: youtubeClientUserAgent })
+    if (backgroundReceiver) waitForDialOrShowWindow()
 
     //remember fullscreen preference
     win.on('enter-full-screen', () => {
@@ -468,4 +541,4 @@ function portable() {
     }
 }
 
-main()
+if (gotSingleInstanceLock) main()

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,22 @@ const runningOnSteam = process.env.SteamOS === '1' && process.env.SteamGamepadUI
 let win;
 let config;
 
+const backgroundReceiver = !!argv['background-receiver'];
+
+function getRequestedFullscreen() {
+    return argv['fullscreen'] || runningOnSteam || config.fullscreen || false;
+}
+
+function showReceiverWindow() {
+    if (!win || win.isDestroyed()) return;
+
+    win.setSkipTaskbar(false)
+    if (win.isMinimized()) win.restore()
+    win.show()
+    win.setFullScreen(getRequestedFullscreen())
+    win.focus()
+}
+
 async function main() {
     if (argv['version'] || argv['v']) {
         process.stdout.write(`VacuumTube ${package.version}\n`, () => { //console.log then process.exit isn't safe since console.log is async, so that's why it's done with process.stdout instead
@@ -117,7 +133,7 @@ async function main() {
     }
 
     electron.app.on('window-all-closed', () => {
-        if (process.platform !== 'darwin') electron.app.quit()
+        if (process.platform !== 'darwin' || backgroundReceiver) electron.app.quit()
     })
 
     electron.app.on('before-quit', () => {
@@ -237,6 +253,10 @@ async function main() {
         event.returnValue = config;
     })
 
+    electron.ipcMain.on('dial-launch-request', () => {
+        if (backgroundReceiver) showReceiverWindow()
+    })
+
     //etc helpers
     electron.ipcMain.handle('is-focused', () => {
         if (win) {
@@ -288,25 +308,33 @@ async function main() {
 
     userstyles.startWatcher()
 
-    electron.app.on('activate', () => {
-        if (electron.BrowserWindow.getAllWindows().length === 0) createWindow()
+    electron.app.on('activate', async () => {
+        if (electron.BrowserWindow.getAllWindows().length === 0) {
+            await createWindow()
+        }
+
+        if (backgroundReceiver) showReceiverWindow()
     })
 }
 
 async function createWindow() {
-    let fullscreen = argv['fullscreen'] || runningOnSteam || config.fullscreen || false;
+    const fullscreen = getRequestedFullscreen()
+    const initialFullscreen = backgroundReceiver ? false : fullscreen;
     let noWindowDecs = argv['no-window-decorations'] || config.no_window_decorations || false;
 
     win = new electron.BrowserWindow({
         width: 1200,
         height: 675,
+        show: false,
+        skipTaskbar: backgroundReceiver,
         backgroundColor: '#282828',
-        fullscreen, //this sometimes doesn't work for people, so it's repeated below
+        fullscreen: initialFullscreen, //this sometimes doesn't work for people, so it's repeated below
         fullscreenable: true, //explicitly enable fullscreen functionality on macOS
         titleBarStyle: noWindowDecs ? 'hidden' : 'default',
         frame: noWindowDecs ? false : true,
         icon: './assets/icon.png',
         webPreferences: {
+            backgroundThrottling: !backgroundReceiver,
             nodeIntegration: false,
             contextIsolation: false,
             sandbox: false, //allows me to use node apis in preload, but doesn't allow youtube to do so (solely need node apis for requiring the modules)
@@ -314,6 +342,10 @@ async function createWindow() {
             preload: path.join(__dirname, 'preload/index.js')
         },
         title: 'VacuumTube'
+    })
+
+    win.on('closed', () => {
+        win = null;
     })
 
     // Ensure the *content* area (excluding OS window borders) stays 16:9 on all platforms.
@@ -354,9 +386,12 @@ async function createWindow() {
     win.setAutoHideMenuBar(false)
 
     win.once('ready-to-show', () => {
-        win.setFullScreen(fullscreen)
         win.setAlwaysOnTop(config.keep_on_top)
-        win.show()
+
+        if (!backgroundReceiver) {
+            win.setFullScreen(fullscreen)
+            win.show()
+        }
     })
 
     if (argv['debug-gpu']) {

--- a/src/preload/modules/h5vcc/dial/discover.js
+++ b/src/preload/modules/h5vcc/dial/discover.js
@@ -2,43 +2,89 @@ const dgram = require('dgram')
 const http = require('./http')
 const constants = require('./constants')
 
-const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+let socket = null;
 
-socket.bind(constants.port, () => {
-    socket.addMembership(constants.address)
-})
+function handleMessage(msg, rinfo) {
+    if (msg.length === 0) return;
 
-socket.on('message', (msg, rinfo) => {
-    if (msg.length > 0) {
-        try {
-            let ssdp = parseSSDP(msg)
-            if (ssdp.method !== 'M-SEARCH' || ssdp.path !== '*') return;
+    try {
+        let ssdp = parseSSDP(msg)
+        if (ssdp.method !== 'M-SEARCH' || ssdp.path !== '*') return;
 
-            let response = createSSDP({
-                status: 200,
-                statusText: 'OK',
-                headers: {
-                    'CACHE-CONTROL': 'max-age=1800',
-                    'DATE': `${new Date().toGMTString()}`,
-                    'EXT': '',
-                    'LOCATION': `${http.base}/`,
-                    'SERVER': `${constants.osAgent} UPnP/1.0 ${constants.appAgent}`,
-                    'ST': 'urn:dial-multiscreen-org:service:dial:1',
-                    'USN': `uuid:${constants.uuid()}::urn:dial-multiscreen-org:service:dial:1`
-                }
-            })
+        let response = createSSDP({
+            status: 200,
+            statusText: 'OK',
+            headers: {
+                'CACHE-CONTROL': 'max-age=1800',
+                'DATE': `${new Date().toGMTString()}`,
+                'EXT': '',
+                'LOCATION': `${http.base}/`,
+                'SERVER': `${constants.osAgent} UPnP/1.0 ${constants.appAgent}`,
+                'ST': 'urn:dial-multiscreen-org:service:dial:1',
+                'USN': `uuid:${constants.uuid()}::urn:dial-multiscreen-org:service:dial:1`
+            }
+        })
 
-            let sock = dgram.createSocket({ type: 'udp4', reuseAddr: true })
-            sock.connect(rinfo.port, rinfo.address, () => {
-                sock.send(response, (err) => {
-                    sock.close()
-                })
-            })
-        } catch (err) {
-            console.error('[h5vcc] DIAL: Failed to handle SSDP discovery', err)
-        }
+        let replySocket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+        replySocket.connect(rinfo.port, rinfo.address, () => {
+            replySocket.send(response, () => replySocket.close())
+        })
+    } catch (err) {
+        console.error('[h5vcc] DIAL: Failed to handle SSDP discovery', err)
     }
-})
+}
+
+async function start() {
+    if (socket) return;
+
+    await new Promise((resolve, reject) => {
+        const nextSocket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+
+        const onStartupError = (err) => {
+            nextSocket.removeAllListeners()
+            try { nextSocket.close() } catch {}
+            reject(err)
+        }
+
+        nextSocket.once('error', onStartupError)
+        nextSocket.bind(constants.port, () => {
+            try {
+                nextSocket.addMembership(constants.address)
+            } catch (err) {
+                onStartupError(err)
+                return;
+            }
+
+            nextSocket.off('error', onStartupError)
+            nextSocket.on('error', (err) => console.error('[h5vcc] DIAL: SSDP socket error', err))
+            nextSocket.on('message', handleMessage)
+            socket = nextSocket;
+            resolve()
+        })
+    })
+}
+
+async function stop() {
+    if (!socket) return;
+
+    const currentSocket = socket;
+    socket = null;
+
+    await new Promise((resolve) => {
+        currentSocket.once('close', resolve)
+        try { currentSocket.dropMembership(constants.address) } catch {}
+        try {
+            currentSocket.close()
+        } catch {
+            resolve()
+        }
+    })
+}
+
+async function restart() {
+    await stop()
+    await start()
+}
 
 function parseSSDP(buf) {
     let str = buf.toString('utf-8')
@@ -81,4 +127,10 @@ function createSSDP(options) {
     }
 
     return `${head}\r\n${headersText}\r\n`;
+}
+
+module.exports = {
+    start,
+    stop,
+    restart
 }

--- a/src/preload/modules/h5vcc/dial/events.js
+++ b/src/preload/modules/h5vcc/dial/events.js
@@ -1,0 +1,3 @@
+const { EventEmitter } = require('events')
+
+module.exports = new EventEmitter()

--- a/src/preload/modules/h5vcc/dial/http.js
+++ b/src/preload/modules/h5vcc/dial/http.js
@@ -22,35 +22,53 @@ function route(method, path, handler) {
     handlers.push([ method, path, handler ])
 }
 
+async function refreshAddress() {
+    const localIP = await getLocalIP()
+    const addr = server.address()
+    if (!addr || typeof addr === 'string') throw new Error('DIAL HTTP server is not listening');
+
+    module.exports.host = localIP;
+    module.exports.port = addr.port;
+    module.exports.base = `http://${localIP}:${addr.port}`
+}
+
 async function listen() {
-    return await new Promise(async (resolve, reject) => {
-        const localIP = await getLocalIP()
+    if (server.listening) {
+        await refreshAddress()
+        return;
+    }
 
-        server.listen(0, (err) => {
-            if (err) {
-                reject(`Failed to start server: ${err}`)
-                return;
-            }
+    await new Promise((resolve, reject) => {
+        const onError = (err) => {
+            server.off('listening', onListening)
+            reject(err)
+        }
 
-            let addr = server.address()
-
-            module.exports.host = localIP;
-            module.exports.port = addr.port;
-            module.exports.base = `http://${localIP}:${addr.port}`
-
+        const onListening = () => {
+            server.off('error', onError)
             resolve()
-        })
-    });
+        }
+
+        server.once('error', onError)
+        server.once('listening', onListening)
+        server.listen(0)
+    })
+
+    await refreshAddress()
 }
 
 async function getLocalIP() {
-    return new Promise((resolve) => {
+    return await new Promise((resolve, reject) => {
         let sock = dgram.createSocket('udp4')
+
+        const finish = (callback, value) => {
+            try { sock.close() } catch {}
+            callback(value)
+        }
+
+        sock.once('error', (err) => finish(reject, err))
         sock.connect(80, '224.0.0.0')
-        sock.on('connect', () => {
-            resolve(sock.address().address)
-            sock.close()
-        })
+        sock.once('connect', () => finish(resolve, sock.address().address))
     });
 }
 

--- a/src/preload/modules/h5vcc/dial/server.js
+++ b/src/preload/modules/h5vcc/dial/server.js
@@ -1,6 +1,6 @@
-const { ipcRenderer } = require('electron')
 const http = require('./http')
 const constants = require('./constants')
+const events = require('./events')
 const package = require('../../../../../package.json')
 
 const doc = new DOMParser().parseFromString('<root/>', 'text/xml')
@@ -78,7 +78,7 @@ async function handle(basePath, callback, req, res) {
         data.responseCode < 300;
 
     if (isSuccessfulLaunch) {
-        ipcRenderer.send('dial-launch-request')
+        events.emit('launch-succeeded', { path: basePath })
     }
 
     if (data.mimeType) headers.append('Content-Type', data.mimeType)

--- a/src/preload/modules/h5vcc/dial/server.js
+++ b/src/preload/modules/h5vcc/dial/server.js
@@ -1,3 +1,4 @@
+const { ipcRenderer } = require('electron')
 const http = require('./http')
 const constants = require('./constants')
 const package = require('../../../../../package.json')
@@ -69,6 +70,15 @@ async function handle(basePath, callback, req, res) {
         res.statusCode = 400;
         res.end()
         return;
+    }
+
+    const isSuccessfulLaunch = req.method === 'POST' &&
+        req.url === basePath &&
+        data.responseCode >= 200 &&
+        data.responseCode < 300;
+
+    if (isSuccessfulLaunch) {
+        ipcRenderer.send('dial-launch-request')
     }
 
     if (data.mimeType) headers.append('Content-Type', data.mimeType)

--- a/src/preload/modules/h5vcc/index.js
+++ b/src/preload/modules/h5vcc/index.js
@@ -1,8 +1,12 @@
 const { ipcRenderer } = require('electron')
 const http = require('./dial/http')
+const discover = require('./dial/discover')
+const dialEvents = require('./dial/events')
 const DialServer = require('./dial/server')
 const configManager = require('../../config')
 const config = configManager.get()
+
+let dialOperation = null;
 
 function getMaxResolution() {
     let resolutions = [ '256x144', '426x240', '640x360', '854x480', '1280x720', '1920x1080', '2560x1440', '3840x2160', '7680x4320' ]
@@ -32,19 +36,58 @@ async function waitForDeviceId() {
     console.warn('[h5vcc] DIAL: Device ID not available after waiting, using fallback UUID')
 }
 
-async function startDial() {
-    if (!config.device_discoverability) return;
+function reportDialStatus(status) {
+    ipcRenderer.send('dial-status', status)
+}
+
+async function startDial({ restart = false } = {}) {
+    if (dialOperation) return await dialOperation;
+
+    dialOperation = (async () => {
+        if (!config.device_discoverability) {
+            if (restart) await discover.stop()
+            reportDialStatus('disabled')
+            return false;
+        }
+
+        try {
+            await waitForDeviceId()
+            await http.listen()
+
+            if (restart) {
+                await discover.restart()
+            } else {
+                await discover.start()
+            }
+
+            console.log(`[h5vcc] DIAL: Server ${restart ? 'refreshed' : 'started'} at ${http.base}`)
+            reportDialStatus('ready')
+            return true;
+        } catch (err) {
+            console.error('[h5vcc] DIAL: Failed to start or refresh server', err)
+            reportDialStatus('failed')
+            return false;
+        }
+    })()
 
     try {
-        await waitForDeviceId()
-        await http.listen()
-        require('./dial/discover')
-
-        console.log('[h5vcc] DIAL: Server started')
-    } catch (err) {
-        console.error('[h5vcc] DIAL: Failed to start server', err)
+        return await dialOperation;
+    } finally {
+        dialOperation = null;
     }
 }
+
+dialEvents.on('launch-succeeded', () => {
+    ipcRenderer.send('dial-launch-succeeded')
+})
+
+ipcRenderer.on('dial-refresh', () => {
+    startDial({ restart: true })
+})
+
+window.addEventListener('online', () => {
+    startDial({ restart: true })
+})
 
 module.exports = async () => {
     const initialDeepLink = await ipcRenderer.invoke('get-deeplink')


### PR DESCRIPTION
## Why this matters

VacuumTube already works well as a TV-style YouTube client, but its current launch behavior assumes that the device is being used mainly as a TV box.

That is not always the case. A Raspberry Pi running Raspberry Pi OS, an HTPC, a Steam Deck in desktop mode, or a regular desktop computer may be connected to a TV while still being used as a normal computer. On those systems, keeping VacuumTube open or fullscreen all the time gets in the way of the desktop.

The workflow this adds is closer to a software Chromecast receiver:

1. Start VacuumTube automatically after login, hidden in the background.
2. Continue using the computer normally.
3. Open YouTube on a phone and select VacuumTube from the Cast menu.
4. VacuumTube appears automatically and starts the TV experience.
5. Minimize it after watching; the receiver stays available for the next Cast request.

This makes VacuumTube useful on multipurpose, full-OS devices without turning them into dedicated appliances.

## What changed

- Added an opt-in `--background-receiver` command-line flag.
- In this mode, VacuumTube creates its window hidden and non-fullscreen, so a Wayland compositor does not map a blank fullscreen surface during startup.
- Background throttling is disabled only for this mode, allowing the renderer-hosted DIAL receiver to remain active while the window is hidden or minimized.
- A successful POST to the root DIAL application endpoint notifies the main process and restores the window automatically.
- The restored window respects the existing Fullscreen setting and the `--fullscreen` flag.
- Minimizing the window keeps VacuumTube and DIAL running; closing the window still exits normally.
- Added README documentation, startup commands, Flatpak instructions, and an explanation of the intended desktop/HTPC workflow.

Normal VacuumTube startup behavior is unchanged unless `--background-receiver` is explicitly supplied.

## Example

```sh
vacuumtube --background-receiver --fullscreen
```

Flatpak:

```sh
flatpak run rocks.shy.VacuumTube --background-receiver --fullscreen
```

## Tested on

- Raspberry Pi 5, ARM64
- Raspberry Pi OS with Labwc/Wayland
- Electron 42.5.0

Verified:

- Hidden startup leaves the desktop visible.
- A forced YouTube TV startup error stays hidden instead of showing a gray fullscreen error surface.
- The DIAL device and application endpoints remain available while hidden.
- A valid DIAL launch request returns `201 Created` and restores VacuumTube fullscreen.
- `node --check` passes for the changed JavaScript files.
- `npm run linux:build-unpacked` completes successfully for Linux ARM64.
