### PR TITLE
Add option to support ultrawide displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ VacuumTube has some settings that you can change, which are located directly in 
   - Allows you to choose which guide tabs are shown on the sidebar
 - Unlock Resolution
   - Removes monitor resolution cap and allows you to watch videos at any resolution
+- Support Ultrawide
+  - Expands the YouTube TV interface to fill ultrawide displays
 - Filter Video Codecs
   - Allows you to block specific video codecs, forcing YouTube to pick an alternative. Similiar to [h264ify](https://github.com/erkserkserks/h264ify), but more powerful
 - Hardware Decoding

--- a/locale/en.json
+++ b/locale/en.json
@@ -67,6 +67,10 @@
             "title": "Unlock Resolution",
             "description": "Removes monitor resolution cap and allows you to watch videos at any resolution. Relaunch after toggling"
         },
+        "support_ultrawide": {
+            "title": "Support Ultrawide",
+            "description": "Expands the YouTube TV interface to fill ultrawide displays"
+        },
         "h264ify": {
             "title": "Filter Video Codecs",
             "description": "Codec filtering options. Relaunch after toggling any of the options.",

--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,7 @@ const defaults = {
     no_window_decorations: false, //whether or not to disable window decorations
     keep_on_top: false, //whether or not to keep window on top
     pause_on_blur: false, //whether or not to pause video when out of focus (such as tabbing out)
+    support_ultrawide: false, //expand the YouTube TV interface to fill ultrawide displays
     userstyles: false, //whether or not to enable custom CSS injection
     disabled_userstyles: [], //array of filenames that are disabled
     touch_overlay: true, //whether or not to enable the touch overlay interface when touch is detected

--- a/src/preload/modules/settings/index.js
+++ b/src/preload/modules/settings/index.js
@@ -54,6 +54,7 @@ let tabs = [
     { id: 'wayland_hdr', hide: process.platform !== 'linux' },
     { id: 'low_memory_mode', },
     { id: 'fullscreen', func: (value) => ipcRenderer.invoke('set-fullscreen', value) },
+    { id: 'support_ultrawide' },
     { id: 'no_window_decorations' },
     { id: 'keep_on_top', func: (value) => ipcRenderer.invoke('set-on-top', value) },
     { id: 'pause_on_blur' },

--- a/src/preload/modules/ultrawide.js
+++ b/src/preload/modules/ultrawide.js
@@ -1,0 +1,46 @@
+//expand the YouTube TV interface to fill ultrawide displays
+
+const { ipcRenderer } = require('electron')
+const configManager = require('../config')
+const css = require('../util/css')
+
+const ultrawideCSS = `
+div#container,
+yt-virtual-list,
+ytlr-section-list-renderer
+ytlr-horizontal-list-renderer,
+ytlr-tv-surface-content-renderer,
+div[idomkey="shadow"],
+ytlr-two-column-renderer,
+yt-route,
+ytlr-welcome-immersive-value-prop
+{
+    width: 100vw !important;
+    max-width: 100vw !important;
+    box-sizing: border-box !important;
+    min-width: 100vw !important;
+}
+`
+
+function update(enabled) {
+    if (enabled) {
+        css.inject('ultrawide', ultrawideCSS)
+    } else {
+        css.delete('ultrawide')
+    }
+}
+
+module.exports = () => {
+    let enabled = configManager.get().support_ultrawide;
+
+    if (enabled) {
+        update(true)
+    }
+
+    ipcRenderer.on('config-update', (event, config) => {
+        if (config.support_ultrawide === enabled) return;
+
+        enabled = config.support_ultrawide;
+        update(enabled)
+    })
+}


### PR DESCRIPTION
Fixes #5 and #213 

Note that for some reason, the UI doesn't render video cards using all available space at first, but after pressing a button (i guess it causes rerender), it uses available spaces.

### Setting:
<img width="3418" height="1426" alt="image" src="https://github.com/user-attachments/assets/9bcec684-3c50-4506-8d82-7fae94081c51" />

### Support off:
<img width="3431" height="1440" alt="image" src="https://github.com/user-attachments/assets/f8f62f4e-9761-46a9-8b93-8dacb097628b" />

### Support on (initial render):
<img width="3432" height="1438" alt="image" src="https://github.com/user-attachments/assets/d2b6816f-f3cd-4ddb-a7cf-3af33264df0f" />

### Support on (after rerender):
<img width="3433" height="1440" alt="image" src="https://github.com/user-attachments/assets/77fe6363-e6c3-4f67-a236-ddfec7a7093e" />

### Support off:
<img width="3433" height="1440" alt="image" src="https://github.com/user-attachments/assets/e6780ab1-9091-42ca-bf55-588fe6f58b31" />

### Support on:
<img width="3435" height="1440" alt="image" src="https://github.com/user-attachments/assets/a3b57d6a-914e-473c-9831-6f15b179fa15" />
