### PR TITLE
Fix macOS microphone permission after app updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "YouTube for TV, on your PC",
     "main": "src/index.js",
     "scripts": {
+        "test": "node --test",
         "start": "electron .",
         "windows:build": "electron-builder --win",
         "mac:build": "electron-builder --mac",

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,8 @@ async function main() {
         electron.app.commandLine.appendSwitch('--no-sandbox') //won't run without this in game mode for me
     }
 
+    await permissions.resetAfterUpdate({ appId, userData })
+
     config = configManager.init({
         fullscreen: !!runningOnSteam //if running on steam in game mode, override fullscreen to be on by default (note that this was broken from 1.3.0 until 1.3.6 due to config bug)
     })

--- a/src/microphone-permission-reset.js
+++ b/src/microphone-permission-reset.js
@@ -1,0 +1,77 @@
+const childProcess = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const versionMarkerName = 'microphone-permission-version'
+
+function resetMicrophonePermission(appId, execFile = childProcess.execFile) {
+    return new Promise((resolve, reject) => {
+        execFile('/usr/bin/tccutil', [ 'reset', 'Microphone', appId ], (err) => {
+            if (err) {
+                reject(err)
+                return;
+            }
+
+            resolve()
+        })
+    });
+}
+
+async function resetAfterAppUpdate(options = {}, dependencies = {}) {
+    const {
+        appId,
+        appVersion,
+        isPackaged,
+        platform = process.platform,
+        userData
+    } = options;
+
+    if (platform !== 'darwin' || !isPackaged) return false;
+
+    const logger = dependencies.logger || console;
+    const filesystem = dependencies.fs || fs;
+    const reset = dependencies.resetMicrophonePermission || resetMicrophonePermission;
+
+    if (!appId || !appVersion || !userData) {
+        logger.error('[Permissions] Cannot track microphone permission version without app metadata')
+        return false;
+    }
+
+    const versionMarker = path.join(userData, versionMarkerName)
+    let previousVersion = null;
+
+    try {
+        previousVersion = filesystem.readFileSync(versionMarker, 'utf-8').trim() || null;
+    } catch (err) {
+        if (err.code !== 'ENOENT') {
+            logger.error('[Permissions] Failed to read microphone permission version:', err)
+        }
+    }
+
+    if (previousVersion === appVersion) return false;
+
+    //Record the attempt before resetting so a failed tccutil call cannot cause a
+    //permission reset loop every time the app launches.
+    try {
+        filesystem.mkdirSync(userData, { recursive: true })
+        filesystem.writeFileSync(versionMarker, `${appVersion}\n`)
+    } catch (err) {
+        logger.error('[Permissions] Failed to save microphone permission version:', err)
+        return false;
+    }
+
+    try {
+        await reset(appId)
+        logger.log(`[Permissions] Reset microphone access for app version ${appVersion}`)
+        return true;
+    } catch (err) {
+        logger.error('[Permissions] Failed to reset microphone access after app update:', err)
+        return false;
+    }
+}
+
+module.exports = {
+    resetAfterAppUpdate,
+    resetMicrophonePermission,
+    versionMarkerName
+}

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,5 +1,5 @@
 const electron = require('electron')
-const childProcess = require('child_process')
+const microphonePermissionReset = require('./microphone-permission-reset.js')
 
 const youtubeOrigin = 'https://www.youtube.com'
 const microphonePrivacySettingsUrl = 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone'
@@ -72,16 +72,21 @@ async function requestMicrophonePermissionStatus() {
 async function resetMicrophonePermissionStatus() {
     if (process.platform !== 'darwin') return 'unsupported';
 
-    return await new Promise((resolve) => {
-        childProcess.execFile('/usr/bin/tccutil', [ 'reset', 'Microphone', appId ], (err) => {
-            if (err) {
-                console.error('[Permissions] Failed to reset microphone access:', err)
-                resolve('unknown')
-                return;
-            }
+    try {
+        await microphonePermissionReset.resetMicrophonePermission(appId)
+        return getMicrophonePermissionStatus();
+    } catch (err) {
+        console.error('[Permissions] Failed to reset microphone access:', err)
+        return 'unknown';
+    }
+}
 
-            resolve(getMicrophonePermissionStatus())
-        })
+function resetAfterUpdate(options = {}) {
+    return microphonePermissionReset.resetAfterAppUpdate({
+        ...options,
+        appVersion: electron.app.getVersion(),
+        isPackaged: electron.app.isPackaged,
+        platform: process.platform
     });
 }
 
@@ -159,5 +164,6 @@ function setup(options = {}) {
 }
 
 module.exports = {
+    resetAfterUpdate,
     setup
 }

--- a/test/microphone-permission-reset.test.js
+++ b/test/microphone-permission-reset.test.js
@@ -1,0 +1,148 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+    resetAfterAppUpdate,
+    resetMicrophonePermission,
+    versionMarkerName
+} = require('../src/microphone-permission-reset.js')
+
+const silentLogger = {
+    error() {},
+    log() {}
+}
+
+function createUserData(t) {
+    const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'vacuumtube-permissions-'))
+    t.after(() => fs.rmSync(userData, { recursive: true, force: true }))
+    return userData;
+}
+
+function macOptions(userData, appVersion = '1.8.2') {
+    return {
+        appId: 'rocks.shy.VacuumTube',
+        appVersion,
+        isPackaged: true,
+        platform: 'darwin',
+        userData
+    };
+}
+
+test('resets only the VacuumTube microphone decision with tccutil', async () => {
+    let command = null;
+    let args = null;
+
+    await resetMicrophonePermission('rocks.shy.VacuumTube', (receivedCommand, receivedArgs, callback) => {
+        command = receivedCommand;
+        args = receivedArgs;
+        callback(null)
+    })
+
+    assert.equal(command, '/usr/bin/tccutil')
+    assert.deepEqual(args, [ 'reset', 'Microphone', 'rocks.shy.VacuumTube' ])
+})
+
+test('resets microphone permission on the first packaged macOS launch', async (t) => {
+    const userData = createUserData(t)
+    const resetCalls = []
+
+    const didReset = await resetAfterAppUpdate(macOptions(userData), {
+        logger: silentLogger,
+        resetMicrophonePermission: async (appId) => resetCalls.push(appId)
+    })
+
+    assert.equal(didReset, true)
+    assert.deepEqual(resetCalls, [ 'rocks.shy.VacuumTube' ])
+    assert.equal(fs.readFileSync(path.join(userData, versionMarkerName), 'utf-8'), '1.8.2\n')
+})
+
+test('does not reset again while the app version is unchanged', async (t) => {
+    const userData = createUserData(t)
+    const marker = path.join(userData, versionMarkerName)
+    fs.writeFileSync(marker, '1.8.2\n')
+
+    let resetCount = 0;
+    const didReset = await resetAfterAppUpdate(macOptions(userData), {
+        logger: silentLogger,
+        resetMicrophonePermission: async () => resetCount++
+    })
+
+    assert.equal(didReset, false)
+    assert.equal(resetCount, 0)
+})
+
+test('resets once when the packaged app version changes', async (t) => {
+    const userData = createUserData(t)
+    const marker = path.join(userData, versionMarkerName)
+    fs.writeFileSync(marker, '1.8.1\n')
+
+    let resetCount = 0;
+    const didReset = await resetAfterAppUpdate(macOptions(userData), {
+        logger: silentLogger,
+        resetMicrophonePermission: async () => resetCount++
+    })
+
+    assert.equal(didReset, true)
+    assert.equal(resetCount, 1)
+    assert.equal(fs.readFileSync(marker, 'utf-8'), '1.8.2\n')
+})
+
+test('leaves development runs and other platforms untouched', async (t) => {
+    const userData = createUserData(t)
+    let resetCount = 0;
+    const dependencies = {
+        logger: silentLogger,
+        resetMicrophonePermission: async () => resetCount++
+    };
+
+    const developmentReset = await resetAfterAppUpdate({
+        ...macOptions(userData),
+        isPackaged: false
+    }, dependencies)
+    const windowsReset = await resetAfterAppUpdate({
+        ...macOptions(userData),
+        platform: 'win32'
+    }, dependencies)
+
+    assert.equal(developmentReset, false)
+    assert.equal(windowsReset, false)
+    assert.equal(resetCount, 0)
+    assert.equal(fs.existsSync(path.join(userData, versionMarkerName)), false)
+})
+
+test('records a failed reset attempt so it does not loop on every launch', async (t) => {
+    const userData = createUserData(t)
+    let resetCount = 0;
+    const dependencies = {
+        logger: silentLogger,
+        resetMicrophonePermission: async () => {
+            resetCount++
+            throw new Error('tccutil failed')
+        }
+    };
+
+    const firstReset = await resetAfterAppUpdate(macOptions(userData), dependencies)
+    const secondReset = await resetAfterAppUpdate(macOptions(userData), dependencies)
+
+    assert.equal(firstReset, false)
+    assert.equal(secondReset, false)
+    assert.equal(resetCount, 1)
+})
+
+test('does not reset when it cannot save the version marker', async (t) => {
+    const userData = createUserData(t)
+    const invalidUserData = path.join(userData, 'not-a-directory')
+    fs.writeFileSync(invalidUserData, 'file')
+
+    let resetCount = 0;
+    const didReset = await resetAfterAppUpdate(macOptions(invalidUserData), {
+        logger: silentLogger,
+        resetMicrophonePermission: async () => resetCount++
+    })
+
+    assert.equal(didReset, false)
+    assert.equal(resetCount, 0)
+})


### PR DESCRIPTION
## Summary

I noticed that after updating VacuumTube on macOS, voice search kept showing permission popups even though Settings still said the microphone was allowed.

Because the app is currently ad-hoc signed, an updated build can have a new macOS security identity while the old microphone decision remains. This resets that decision once after an update so the new build can request access normally.

## What changed

- Reset only VacuumTube's microphone permission on the first launch of each packaged macOS version.
- Save the handled version so the reset does not repeat on every launch.
- Reuse the same reset code for the existing Settings button.
- Leave development builds, Windows, and Linux unchanged.
- Add tests for updates, repeat launches, and failures.

## Testing

- [x] `npm test` — 7 tests passed
- [x] Syntax and diff checks passed
- [x] arm64 macOS package built successfully
- [x] Verified the helper, bundle ID, and microphone description in the packaged app
- [ ] Still needs a final two-version macOS test with a real permission prompt

The reset follows the app version. If macOS builds become properly signed later, this behavior should be revisited.
