### PR TITLE
Add opt-in Steam Overlay compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ VacuumTube has some settings that you can change, which are located directly in 
   - Disables window decorations, including the title bar and window border
 - Keep on Top
   - Enables Keep on Top, and makes VacuumTube launch with the window pinned on top of every other window
+- Steam Overlay Compatibility
+  - Helps Steam Big Picture attach its overlay when VacuumTube is launched as a non-Steam game on Windows. Relaunch after toggling. Leave this off unless you use VacuumTube through Steam
 - Pause on Blur
   - Pause current video when VacuumTube loses focus (e.g. tabbing out or minimizing the window)
 - Features
@@ -166,6 +168,22 @@ The userstyles folder is located in the config folder mentioned below.
 You can provide extra command line flags to Chromium via the `flags.txt` file located in the config folder.
 
 For example, putting `--disable-gpu` into the `flags.txt` file will cause VacuumTube to run with the GPU disabled. You can find more flags by searching for Chromium command line flags, but you likely won't need to mess with this.
+
+If you are trying to use Steam Big Picture's overlay with VacuumTube, use the **Steam Overlay Compatibility** setting instead of adding GPU or DirectComposition flags manually. The setting applies the required startup switches together on the next launch and keeps the normal default behavior unchanged while it is off.
+
+## Steam Big Picture Acceptance Test
+
+This Windows-only check needs Steam and cannot be automated by the regular Node test suite:
+
+1. Launch VacuumTube normally.
+2. Open VacuumTube Settings with `Ctrl+O`.
+3. Enable **Steam Overlay Compatibility**.
+4. Quit and relaunch VacuumTube once so the Chromium startup switches take effect.
+5. Add the same `VacuumTube.exe` to Steam as a non-Steam game.
+6. Launch VacuumTube from Steam Big Picture.
+7. Open the Steam overlay and verify that it appears over VacuumTube.
+8. While the overlay is open, verify controller input moves through the Steam overlay rather than the YouTube TV interface.
+9. Close the overlay and verify controller input returns to VacuumTube.
 
 ## Config Folder
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ VacuumTube has some settings that you can change, which are located directly in 
   - Disables window decorations, including the title bar and window border
 - Keep on Top
   - Enables Keep on Top, and makes VacuumTube launch with the window pinned on top of every other window
-- Steam Overlay Compatibility
-  - Helps Steam Big Picture attach its overlay when VacuumTube is launched as a non-Steam game on Windows. Relaunch after toggling. Leave this off unless you use VacuumTube through Steam
 - Pause on Blur
   - Pause current video when VacuumTube loses focus (e.g. tabbing out or minimizing the window)
 - Features
@@ -168,22 +166,6 @@ The userstyles folder is located in the config folder mentioned below.
 You can provide extra command line flags to Chromium via the `flags.txt` file located in the config folder.
 
 For example, putting `--disable-gpu` into the `flags.txt` file will cause VacuumTube to run with the GPU disabled. You can find more flags by searching for Chromium command line flags, but you likely won't need to mess with this.
-
-If you are trying to use Steam Big Picture's overlay with VacuumTube, use the **Steam Overlay Compatibility** setting instead of adding GPU or DirectComposition flags manually. The setting applies the required startup switches together on the next launch and keeps the normal default behavior unchanged while it is off.
-
-## Steam Big Picture Acceptance Test
-
-This Windows-only check needs Steam and cannot be automated by the regular Node test suite:
-
-1. Launch VacuumTube normally.
-2. Open VacuumTube Settings with `Ctrl+O`.
-3. Enable **Steam Overlay Compatibility**.
-4. Quit and relaunch VacuumTube once so the Chromium startup switches take effect.
-5. Add the same `VacuumTube.exe` to Steam as a non-Steam game.
-6. Launch VacuumTube from Steam Big Picture.
-7. Open the Steam overlay and verify that it appears over VacuumTube.
-8. While the overlay is open, verify controller input moves through the Steam overlay rather than the YouTube TV interface.
-9. Close the overlay and verify controller input returns to VacuumTube.
 
 ## Config Folder
 

--- a/locale/en.json
+++ b/locale/en.json
@@ -99,6 +99,10 @@
             "title": "Keep on Top",
             "description": "Enables Keep on Top, and makes VacuumTube launch with the window pinned on top of every other window"
         },
+        "steam_overlay_compatibility": {
+            "title": "Steam Overlay Compatibility",
+            "description": "Helps Steam Big Picture attach its overlay when VacuumTube is launched as a non-Steam game. Windows only. Relaunch after toggling."
+        },
         "pause_on_blur": {
             "title": "Pause on Blur",
             "description": "Pause current video when VacuumTube loses focus (e.g. tabbing out or minimizing the window)"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "src/index.js",
     "scripts": {
         "start": "electron .",
+        "test": "node --test",
         "windows:build": "electron-builder --win",
         "mac:build": "electron-builder --mac",
         "linux:build": "electron-builder --linux",

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,7 @@ const defaults = {
     music_mode: false,
     no_window_decorations: false, //whether or not to disable window decorations
     keep_on_top: false, //whether or not to keep window on top
+    steam_overlay_compatibility: false, //windows-only compatibility mode for Steam's non-Steam game overlay
     pause_on_blur: false, //whether or not to pause video when out of focus (such as tabbing out)
     userstyles: false, //whether or not to enable custom CSS injection
     disabled_userstyles: [], //array of filenames that are disabled

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ electron.app.setPath('sessionData', sessionData)
 const configManager = require('./config.js')
 const permissions = require('./permissions.js')
 const userstyles = require('./userstyles.js')
+const { applySteamOverlayCompatibilitySwitches } = require('./steam-overlay-compatibility.js')
 
 //code
 /*
@@ -85,6 +86,11 @@ async function main() {
             electron.app.commandLine.appendSwitch(key, value)
         }
     }
+
+    applySteamOverlayCompatibilitySwitches({
+        commandLine: electron.app.commandLine,
+        config
+    })
 
     let enabledFeatures = electron.app.commandLine.getSwitchValue('enable-features').split(',')
     let disabledFeatures = electron.app.commandLine.getSwitchValue('disable-features').split(',')

--- a/src/preload/modules/settings/index.js
+++ b/src/preload/modules/settings/index.js
@@ -56,6 +56,7 @@ let tabs = [
     { id: 'fullscreen', func: (value) => ipcRenderer.invoke('set-fullscreen', value) },
     { id: 'no_window_decorations' },
     { id: 'keep_on_top', func: (value) => ipcRenderer.invoke('set-on-top', value) },
+    { id: 'steam_overlay_compatibility', hide: process.platform !== 'win32' },
     { id: 'pause_on_blur' },
     { id: 'features' },
     { id: 'userstyles' },

--- a/src/preload/modules/steam-overlay-compatibility.js
+++ b/src/preload/modules/steam-overlay-compatibility.js
@@ -1,0 +1,59 @@
+// Keeps a transparent Chromium-rendered surface active for Steam's non-Steam game overlay.
+
+const { isSteamOverlayCompatibilitySupported } = require('../../steam-overlay-compatibility')
+
+async function runSteamOverlayCompatibilityModule({
+    platform = process.platform,
+    ipcRenderer,
+    configManager,
+    waitForCondition,
+    createSurface,
+    win = window,
+    doc = document
+}) {
+    if (!isSteamOverlayCompatibilitySupported(platform)) return false;
+
+    const surface = createSurface(win, doc)
+
+    function sync(newConfig = configManager.get()) {
+        if (newConfig.steam_overlay_compatibility) {
+            surface.start()
+        } else {
+            surface.stop()
+        }
+    }
+
+    function cleanup() {
+        surface.stop()
+        ipcRenderer.removeListener('config-update', onConfigUpdate)
+        win.removeEventListener('beforeunload', cleanup)
+    }
+
+    function onConfigUpdate(event, newConfig) {
+        sync(newConfig)
+    }
+
+    await waitForCondition(() => !!doc.body)
+
+    sync()
+    ipcRenderer.on('config-update', onConfigUpdate)
+    win.addEventListener('beforeunload', cleanup)
+
+    return true;
+}
+
+module.exports = async () => {
+    const { ipcRenderer } = require('electron')
+    const configManager = require('../config')
+    const functions = require('../util/functions')
+    const { createSteamOverlayCompatibilitySurface } = require('../util/steamOverlayCompatibilitySurface')
+
+    return runSteamOverlayCompatibilityModule({
+        ipcRenderer,
+        configManager,
+        waitForCondition: functions.waitForCondition,
+        createSurface: createSteamOverlayCompatibilitySurface
+    })
+}
+
+module.exports.runSteamOverlayCompatibilityModule = runSteamOverlayCompatibilityModule

--- a/src/preload/util/steamOverlayCompatibilitySurface.js
+++ b/src/preload/util/steamOverlayCompatibilitySurface.js
@@ -1,0 +1,118 @@
+const CANVAS_ID = 'vt-steam-overlay-compatibility-surface'
+
+const canvasStyle = Object.freeze({
+    position: 'fixed',
+    inset: '0',
+    width: '100vw',
+    height: '100vh',
+    pointerEvents: 'none',
+    background: 'transparent',
+    zIndex: '2147483647',
+    contain: 'strict',
+    transform: 'translateZ(0)',
+    willChange: 'transform'
+})
+
+function getSurfaceSize(win) {
+    const pixelRatio = Math.max(1, Number(win.devicePixelRatio) || 1)
+    const width = Math.max(1, Math.ceil((Number(win.innerWidth) || 1) * pixelRatio))
+    const height = Math.max(1, Math.ceil((Number(win.innerHeight) || 1) * pixelRatio))
+
+    return { width, height }
+}
+
+function createSteamOverlayCompatibilitySurface(win = window, doc = document) {
+    let canvas = null;
+    let context = null;
+    let animationId = null;
+    let frame = 0;
+
+    function resize() {
+        if (!canvas) return;
+
+        const { width, height } = getSurfaceSize(win)
+        if (canvas.width !== width) canvas.width = width;
+        if (canvas.height !== height) canvas.height = height;
+    }
+
+    function draw() {
+        if (!canvas || !context) return;
+
+        resize()
+
+        const alpha = frame % 2 === 0 ? '0.001' : '0.003'
+        context.clearRect(0, 0, 2, 2)
+        context.fillStyle = `rgba(0, 0, 0, ${alpha})`
+        context.fillRect(0, 0, 2, 2)
+
+        frame++;
+        animationId = win.requestAnimationFrame(draw)
+    }
+
+    function start() {
+        if (canvas) return false;
+
+        const parent = doc.body || doc.documentElement;
+        if (!parent) return false;
+
+        canvas = doc.createElement('canvas')
+        canvas.id = CANVAS_ID;
+        canvas.setAttribute('aria-hidden', 'true')
+        Object.assign(canvas.style, canvasStyle)
+
+        context = canvas.getContext('2d', {
+            alpha: true,
+            desynchronized: true
+        })
+
+        if (!context) {
+            canvas.remove()
+            canvas = null;
+            return false;
+        }
+
+        resize()
+        parent.appendChild(canvas)
+        win.addEventListener('resize', resize)
+        animationId = win.requestAnimationFrame(draw)
+
+        return true;
+    }
+
+    function stop() {
+        if (!canvas) return false;
+
+        if (animationId !== null) {
+            win.cancelAnimationFrame(animationId)
+            animationId = null;
+        }
+
+        win.removeEventListener('resize', resize)
+        canvas.remove()
+        canvas = null;
+        context = null;
+
+        return true;
+    }
+
+    function isRunning() {
+        return !!canvas;
+    }
+
+    function getCanvas() {
+        return canvas;
+    }
+
+    return {
+        start,
+        stop,
+        isRunning,
+        getCanvas
+    }
+}
+
+module.exports = {
+    CANVAS_ID,
+    getSurfaceSize,
+    createSteamOverlayCompatibilitySurface
+}

--- a/src/steam-overlay-compatibility.js
+++ b/src/steam-overlay-compatibility.js
@@ -1,0 +1,60 @@
+const COMPATIBILITY_SWITCHES = Object.freeze([
+    'in-process-gpu',
+    'disable-direct-composition'
+])
+
+function isSteamOverlayCompatibilitySupported(platform = process.platform) {
+    return platform === 'win32';
+}
+
+function getCompatibilitySwitches(platform = process.platform) {
+    if (!isSteamOverlayCompatibilitySupported(platform)) return [];
+
+    return COMPATIBILITY_SWITCHES;
+}
+
+function appendSwitch(commandLine, name) {
+    if (commandLine.hasSwitch?.(name)) return false;
+
+    commandLine.appendSwitch(name)
+    return true;
+}
+
+function applySteamOverlayCompatibilitySwitches({
+    commandLine,
+    config,
+    platform = process.platform,
+    logger = console
+}) {
+    if (!config?.steam_overlay_compatibility) return [];
+
+    const switches = getCompatibilitySwitches(platform)
+    if (switches.length === 0) {
+        logger.warn?.('[Steam Overlay Compatibility] Startup switches are only applied on Windows.')
+        return [];
+    }
+
+    const applied = []
+    for (const name of switches) {
+        if (appendSwitch(commandLine, name)) {
+            applied.push(name)
+        }
+    }
+
+    if (commandLine.hasSwitch?.('disable-gpu')) {
+        logger.warn?.('[Steam Overlay Compatibility] --disable-gpu is also set; Steam overlay injection may still fail.')
+    }
+
+    if (applied.length > 0) {
+        logger.log?.(`[Steam Overlay Compatibility] Applied Chromium switches: ${applied.join(', ')}`)
+    }
+
+    return applied;
+}
+
+module.exports = {
+    COMPATIBILITY_SWITCHES,
+    isSteamOverlayCompatibilitySupported,
+    getCompatibilitySwitches,
+    applySteamOverlayCompatibilitySwitches
+}

--- a/test/steam-overlay-compatibility.test.js
+++ b/test/steam-overlay-compatibility.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+    isSteamOverlayCompatibilitySupported,
+    getCompatibilitySwitches,
+    applySteamOverlayCompatibilitySwitches
+} = require('../src/steam-overlay-compatibility')
+
+test('steam overlay compatibility is supported only on Windows', () => {
+    assert.equal(isSteamOverlayCompatibilitySupported('win32'), true)
+    assert.equal(isSteamOverlayCompatibilitySupported('linux'), false)
+    assert.equal(isSteamOverlayCompatibilitySupported('darwin'), false)
+})
+
+test('steam overlay compatibility has no startup switches outside Windows', () => {
+    assert.deepEqual(getCompatibilitySwitches('linux'), [])
+    assert.deepEqual(getCompatibilitySwitches('darwin'), [])
+})
+
+test('steam overlay compatibility applies the Windows switch bundle when enabled', () => {
+    const appended = []
+    const commandLine = {
+        hasSwitch: () => false,
+        appendSwitch: (name) => appended.push(name)
+    }
+
+    const applied = applySteamOverlayCompatibilitySwitches({
+        commandLine,
+        config: { steam_overlay_compatibility: true },
+        platform: 'win32',
+        logger: silentLogger()
+    })
+
+    assert.deepEqual(applied, [
+        'in-process-gpu',
+        'disable-direct-composition'
+    ])
+    assert.deepEqual(appended, applied)
+})
+
+test('steam overlay compatibility does not apply switches while disabled', () => {
+    const appended = []
+
+    const applied = applySteamOverlayCompatibilitySwitches({
+        commandLine: {
+            hasSwitch: () => false,
+            appendSwitch: (name) => appended.push(name)
+        },
+        config: { steam_overlay_compatibility: false },
+        platform: 'win32',
+        logger: silentLogger()
+    })
+
+    assert.deepEqual(applied, [])
+    assert.deepEqual(appended, [])
+})
+
+test('steam overlay compatibility does not duplicate existing command-line switches', () => {
+    const existing = new Set(['in-process-gpu'])
+    const appended = []
+
+    const applied = applySteamOverlayCompatibilitySwitches({
+        commandLine: {
+            hasSwitch: (name) => existing.has(name),
+            appendSwitch: (name) => {
+                existing.add(name)
+                appended.push(name)
+            }
+        },
+        config: { steam_overlay_compatibility: true },
+        platform: 'win32',
+        logger: silentLogger()
+    })
+
+    assert.deepEqual(applied, ['disable-direct-composition'])
+    assert.deepEqual(appended, applied)
+})
+
+function silentLogger() {
+    return {
+        log: () => {},
+        warn: () => {}
+    }
+}

--- a/test/steam-overlay-surface.test.js
+++ b/test/steam-overlay-surface.test.js
@@ -1,0 +1,245 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+    CANVAS_ID,
+    getSurfaceSize,
+    createSteamOverlayCompatibilitySurface
+} = require('../src/preload/util/steamOverlayCompatibilitySurface')
+const { runSteamOverlayCompatibilityModule } = require('../src/preload/modules/steam-overlay-compatibility')
+
+test('steam overlay surface sizes itself to device pixels', () => {
+    assert.deepEqual(getSurfaceSize({
+        innerWidth: 640,
+        innerHeight: 360,
+        devicePixelRatio: 1.5
+    }), {
+        width: 960,
+        height: 540
+    })
+})
+
+test('steam overlay surface starts and stops a transparent animation layer', () => {
+    const env = createFakeDomEnvironment()
+    const surface = createSteamOverlayCompatibilitySurface(env.window, env.document)
+
+    assert.equal(surface.isRunning(), false)
+    assert.equal(surface.start(), true)
+
+    const canvas = surface.getCanvas()
+    assert.equal(surface.isRunning(), true)
+    assert.equal(canvas.id, CANVAS_ID)
+    assert.equal(canvas.attributes['aria-hidden'], 'true')
+    assert.equal(canvas.style.pointerEvents, 'none')
+    assert.equal(canvas.style.position, 'fixed')
+    assert.equal(canvas.width, 1600)
+    assert.equal(canvas.height, 900)
+    assert.equal(env.document.body.children.includes(canvas), true)
+    assert.equal(env.window.listenerCount('resize'), 1)
+    assert.equal(env.window.queuedFrames.length, 1)
+
+    env.window.flushAnimationFrame()
+
+    assert.deepEqual(canvas.context.calls.slice(0, 2), [
+        ['clearRect', 0, 0, 2, 2],
+        ['fillRect', 0, 0, 2, 2]
+    ])
+    assert.equal(env.window.queuedFrames.length, 1)
+
+    assert.equal(surface.stop(), true)
+    assert.equal(surface.isRunning(), false)
+    assert.equal(canvas.removed, true)
+    assert.equal(env.window.listenerCount('resize'), 0)
+    assert.equal(env.window.cancelledFrames.length, 1)
+})
+
+test('steam overlay surface is a no-op when started twice or stopped twice', () => {
+    const env = createFakeDomEnvironment()
+    const surface = createSteamOverlayCompatibilitySurface(env.window, env.document)
+
+    assert.equal(surface.start(), true)
+    assert.equal(surface.start(), false)
+    assert.equal(env.document.body.children.length, 1)
+    assert.equal(surface.stop(), true)
+    assert.equal(surface.stop(), false)
+})
+
+test('steam overlay renderer module does not start outside Windows when config is manually enabled', async () => {
+    const env = createFakeDomEnvironment()
+    const ipcRenderer = createFakeIpcRenderer()
+    const surface = createFakeSurface()
+
+    const loaded = await runSteamOverlayCompatibilityModule({
+        platform: 'linux',
+        ipcRenderer,
+        configManager: {
+            get: () => ({ steam_overlay_compatibility: true })
+        },
+        waitForCondition: async () => {},
+        createSurface: () => surface,
+        win: env.window,
+        doc: env.document
+    })
+
+    assert.equal(loaded, false)
+    assert.equal(surface.started, 0)
+    assert.equal(ipcRenderer.listenerCount('config-update'), 0)
+    assert.equal(env.window.listenerCount('beforeunload'), 0)
+})
+
+test('steam overlay renderer module starts on Windows when config is enabled', async () => {
+    const env = createFakeDomEnvironment()
+    const ipcRenderer = createFakeIpcRenderer()
+    const surface = createFakeSurface()
+
+    const loaded = await runSteamOverlayCompatibilityModule({
+        platform: 'win32',
+        ipcRenderer,
+        configManager: {
+            get: () => ({ steam_overlay_compatibility: true })
+        },
+        waitForCondition: async () => {},
+        createSurface: () => surface,
+        win: env.window,
+        doc: env.document
+    })
+
+    assert.equal(loaded, true)
+    assert.equal(surface.started, 1)
+    assert.equal(ipcRenderer.listenerCount('config-update'), 1)
+    assert.equal(env.window.listenerCount('beforeunload'), 1)
+})
+
+function createFakeDomEnvironment() {
+    const listeners = new Map()
+    const queuedFrames = []
+    const cancelledFrames = []
+
+    const window = {
+        innerWidth: 800,
+        innerHeight: 450,
+        devicePixelRatio: 2,
+        queuedFrames,
+        cancelledFrames,
+        requestAnimationFrame(callback) {
+            const id = queuedFrames.length + cancelledFrames.length + 1
+            queuedFrames.push({ id, callback })
+            return id;
+        },
+        cancelAnimationFrame(id) {
+            cancelledFrames.push(id)
+        },
+        addEventListener(name, handler) {
+            const handlers = listeners.get(name) || []
+            handlers.push(handler)
+            listeners.set(name, handlers)
+        },
+        removeEventListener(name, handler) {
+            const handlers = listeners.get(name) || []
+            listeners.set(name, handlers.filter((item) => item !== handler))
+        },
+        listenerCount(name) {
+            return (listeners.get(name) || []).length;
+        },
+        flushAnimationFrame() {
+            const frame = queuedFrames.shift()
+            if (frame) frame.callback()
+        }
+    }
+
+    const document = {
+        body: createParentNode(),
+        documentElement: createParentNode(),
+        createElement(tagName) {
+            assert.equal(tagName, 'canvas')
+            return createCanvas()
+        }
+    }
+
+    return { window, document }
+}
+
+function createParentNode() {
+    return {
+        children: [],
+        appendChild(node) {
+            this.children.push(node)
+            node.parentNode = this;
+        }
+    }
+}
+
+function createCanvas() {
+    return {
+        id: '',
+        style: {},
+        attributes: {},
+        removed: false,
+        width: 0,
+        height: 0,
+        context: createCanvasContext(),
+        setAttribute(name, value) {
+            this.attributes[name] = value;
+        },
+        getContext(kind, options) {
+            assert.equal(kind, '2d')
+            assert.deepEqual(options, {
+                alpha: true,
+                desynchronized: true
+            })
+
+            return this.context;
+        },
+        remove() {
+            this.removed = true;
+            if (this.parentNode) {
+                this.parentNode.children = this.parentNode.children.filter((node) => node !== this)
+            }
+        }
+    }
+}
+
+function createCanvasContext() {
+    return {
+        calls: [],
+        fillStyle: null,
+        clearRect(...args) {
+            this.calls.push(['clearRect', ...args])
+        },
+        fillRect(...args) {
+            this.calls.push(['fillRect', ...args])
+        }
+    }
+}
+
+function createFakeIpcRenderer() {
+    const listeners = new Map()
+
+    return {
+        on(name, handler) {
+            const handlers = listeners.get(name) || []
+            handlers.push(handler)
+            listeners.set(name, handlers)
+        },
+        removeListener(name, handler) {
+            const handlers = listeners.get(name) || []
+            listeners.set(name, handlers.filter((item) => item !== handler))
+        },
+        listenerCount(name) {
+            return (listeners.get(name) || []).length;
+        }
+    }
+}
+
+function createFakeSurface() {
+    return {
+        started: 0,
+        stopped: 0,
+        start() {
+            this.started++;
+        },
+        stop() {
+            this.stopped++;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in **Steam Overlay Compatibility** setting through VacuumTube's existing settings, config, and localization systems.
- Applies the required Windows Chromium switches before Electron starts.
- Runs a transparent full-window rendering layer only when the setting is enabled.
- Keeps the feature off by default and limits it to Windows.
- Notes in the setting that changes require a restart.
- Adds tests for startup switches, Windows guards, renderer wiring, and rendering-layer cleanup.

Closes #113 and #216.

## Implementation

When enabled on Windows, VacuumTube starts Chromium with `in-process-gpu` and `disable-direct-composition`. It also runs a pointer-transparent full-window canvas using `requestAnimationFrame`.

The renderer code loads only when needed and stops when the window unloads. When the setting is disabled, it does not create the canvas or apply either Chromium switch.

If `disable-gpu` is present, VacuumTube logs a warning and leaves the user's flags unchanged.

This works with VacuumTube added to Steam as a non-Steam shortcut. It does not require the Steamworks SDK or a Steam app ID.

## Verification

- `node --test`: 10 passing
- JavaScript syntax checks passed
- I've been testing this for a few days on windows and it works great
