### PR TITLE
Add keyboad shortcuts for changing playback speed

### DIFF
--- a/src/preload/modules/speed-control/index.js
+++ b/src/preload/modules/speed-control/index.js
@@ -1,0 +1,93 @@
+const fs = require('fs')
+const path = require('path')
+const rcMod = require('../../util/resolveCommandModifiers')
+const css = require('../../util/css')
+const functions = require('../../util/functions')
+const configManager = require('../../config')
+
+const config = configManager.get()
+
+module.exports = async () => {
+    const el = functions.el;
+
+    await functions.waitForCondition(() => !!document.body)
+    const cssPath = path.join(__dirname, 'style.css')
+    const text = fs.readFileSync(cssPath, 'utf-8')
+
+    css.inject('speed-control', text)
+
+    let lastCustomPlaybackRate = config.lastCustomPlaybackRate || 2;
+    let currentPlacbackRate = 1;
+    let speedTimeout;
+
+    function createSpeedIndicator() {
+        return el('div', { id: 'vt-speed-indicator' }, [
+            el('div', { id: 'vt-speed-icon', className: 'vt-speed-icon' }),
+            el('span', { id: 'vt-speed-text', className: 'vt-speed-text' })
+        ]);
+    }
+
+    const speedIndicatorElement = createSpeedIndicator()
+    document.body.appendChild(speedIndicatorElement)
+
+    function showSpeedIndicator() {
+        const indicator = document.getElementById('vt-speed-indicator')
+        const text = document.getElementById('vt-speed-text')
+        if (!indicator || !text) return;
+
+        text.textContent = `${currentPlacbackRate}x`
+        indicator.classList.add('visible')
+
+        clearTimeout(speedTimeout)
+        speedTimeout = setTimeout(() => {
+            indicator.classList.remove('visible')
+        }, 1500)
+    }
+
+    function setPlaybackRate(step) {
+        let players = document.querySelectorAll('.html5-video-player')
+        for (let player of players) {
+            if (!player?.setPlaybackRate) continue;
+
+            if (step == 0) // toggle between normal and last non normal speed
+            {
+                currentPlacbackRate = player.getPlaybackRate()
+                if (currentPlacbackRate != 1) {
+                    lastCustomPlaybackRate = currentPlacbackRate
+                    currentPlacbackRate = 1
+                } else {
+                    currentPlacbackRate = lastCustomPlaybackRate
+                }
+            }
+            else // increase/decreade by step speed
+            {
+                currentPlacbackRate = Math.max(0.25, Math.min(currentPlacbackRate + step, 2)) // clamp between 0.25 and 2
+            }
+
+            player.setPlaybackRate(currentPlacbackRate)
+        }
+    }
+
+    //speed controls
+    document.addEventListener('keydown', (e) => {
+        const key = e.key || e.keyCode; 
+        if (!key) return;
+
+        const speedStep = 0.25;
+
+        if (key === 's' || key === 'S') {
+            setPlaybackRate(0) // toggle
+        } else if (key === 'a' || key === 'A') {
+            setPlaybackRate(speedStep)
+        } else if (key === 'd' || key === 'D') {
+            setPlaybackRate(-speedStep)
+        } else {
+            return;
+        }
+
+        e.preventDefault()
+        e.stopPropagation()
+        e.stopImmediatePropagation()
+        showSpeedIndicator()
+    }, true)
+}

--- a/src/preload/modules/speed-control/index.js
+++ b/src/preload/modules/speed-control/index.js
@@ -16,7 +16,7 @@ module.exports = async () => {
 
     css.inject('speed-control', text)
 
-    let lastCustomPlaybackRate = config.lastCustomPlaybackRate || 2;
+    let lastCustomPlaybackRate = 2;
     let currentPlacbackRate = 1;
     let speedTimeout;
 
@@ -49,9 +49,10 @@ module.exports = async () => {
         for (let player of players) {
             if (!player?.setPlaybackRate) continue;
 
+            currentPlacbackRate = player.getPlaybackRate()
+
             if (step == 0) // toggle between normal and last non normal speed
             {
-                currentPlacbackRate = player.getPlaybackRate()
                 if (currentPlacbackRate != 1) {
                     lastCustomPlaybackRate = currentPlacbackRate
                     currentPlacbackRate = 1
@@ -68,10 +69,26 @@ module.exports = async () => {
         }
     }
 
+    function isWatching() {
+        let isShort = !!document.querySelector('ytlr-shorts-page')?.classList?.contains('zylon-focus')
+        if (isShort) { //very dumb, don't like it, but there doesn't seem to be a better way
+            return true;
+        } else {
+            let baseUri = window.yt?.player?.utils?.videoElement_?.baseURI;
+            if (!baseUri || !baseUri.includes('/watch?v=')) return false;
+
+            let id = baseUri.split('/watch?v=')[1]?.slice(0, 11)
+            if (!id) return false;
+
+            return true;
+        }
+    }
+
     //speed controls
     document.addEventListener('keydown', (e) => {
         const key = e.key || e.keyCode; 
-        if (!key) return;
+        if (!key || !isWatching())
+            return;
 
         const speedStep = 0.25;
 

--- a/src/preload/modules/speed-control/style.css
+++ b/src/preload/modules/speed-control/style.css
@@ -1,0 +1,38 @@
+#vt-speed-indicator {
+    position: fixed;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    padding: 12px 24px;
+    border-radius: 1.5rem;
+    display: flex;
+    align-items: center;
+    z-index: 999999;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+    pointer-events: none;
+}
+
+#vt-speed-indicator.visible {
+    opacity: 1;
+}
+
+.vt-speed-icon {
+    width: 24px;
+    height: 24px;
+    margin-right: 16px;
+    font-size: 24px;
+}
+
+.vt-speed-icon::before {
+    content: '\23e9';
+}
+
+.vt-speed-text {
+    font-size: 18px;
+    font-weight: 500;
+    min-width: 30px;
+    text-align: right;
+}


### PR DESCRIPTION
Adds keyboard shortcuts for quickly changing the playback speed of the video player, as suggested in issue #238

- Press "a" to accelerate the video in 0.25x steps
- Press "d" to deceleration the video in 0.25x steps
- Press "s" to toggle between normal playback speed (1x) and the last custom speed set. Defaults to 2x speed if no custom speed has been set before.

I've copied and adapted a lot of the code from the already existing volume-control module, since this is basically doing the same thing, just setting playback speed instead of volume.