### PR TITLE
feat: add configurable sponsorblock categories

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -27,7 +27,41 @@
         },
         "sponsorblock": {
             "title": "SponsorBlock",
-            "description": "Skips sponsor segments in YouTube videos using a crowdsourced database. Currently only supports skipping sponsors"
+            "description": "Skips sponsor segments in YouTube videos using a crowdsourced database.",
+            "categories": {
+                "sponsor": {
+                    "name": "Sponsor",
+                    "description": "Paid promotion, paid referrals and direct advertisements. Not for self-promotion or free shoutouts to causes/creators/websites/products they like."
+                },
+                "selfpromo": {
+                    "name": "Unpaid/Self Promotion",
+                    "description": "Similar to 'sponsor' except for unpaid or self promotion. This includes sections about merchandise, donations, or information about who they collaborated with."
+                },
+                "interaction": {
+                    "name": "Interaction Reminder (Subscribe)",
+                    "description": "When there is a short reminder to like, subscribe or follow them in the middle of content. If it is long or about something specific, it should be under self promotion instead."
+                },
+                "intro": {
+                    "name": "Intermission/Intro Animation",
+                    "description": "An interval without actual content. Could be a pause, static frame, repeating animation. This should not be used for transitions containing information."
+                },
+                "outro": {
+                    "name": "Endcards/Credits",
+                    "description": "Credits or when the YouTube endcards appear. Not for conclusions with information."
+                },
+                "preview": {
+                    "name": "Preview/Recap",
+                    "description": "Collection of clips that show what is coming up in in this video or other videos in a series where all information is repeated later in the video."
+                },
+                "hook": {
+                    "name": "Hook/Greetings",
+                    "description": "Narrated trailers for the upcoming video, greetings and goodbyes. This should not skip conclusions with information."
+                },
+                "filler": {
+                    "name": "Tangents/Jokes",
+                    "description": "Tangential scenes or jokes that are not required to understand the main content of the video. This should not include segments providing context or background details. This is a very aggressive category meant for when you aren't in the mood for 'fun'."
+                }
+            }
         },
         "dearrow": {
             "title": "DeArrow",
@@ -161,7 +195,14 @@
         }
     },
     "sponsorblock": {
-        "sponsor_skipped": "Sponsor skipped"
+        "sponsor_skipped": "Sponsor skipped",
+        "selfpromo_skipped": "Self Promo skipped",
+        "interaction_skipped": "Interaction skipped",
+        "intro_skipped": "Intro skipped",
+        "outro_skipped": "Outro skipped",
+        "preview_skipped": "Preview skipped",
+        "hook_skipped": "Hook/Greetings skipped",
+        "filler_skipped": "Tangents/Jokes skipped"
     },
     "donate": {
         "setting": {

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,14 @@ const defaults = {
     adblock: true, //block ads
     sponsorblock: false, //enable sponsorblock
     sponsorblock_uuid: crypto.randomUUID(), //sponsorblock wants to track this per user so you can ask it for stats later
+    sponsorblock_skip_sponsor: true,
+    sponsorblock_skip_selfpromo: false,
+    sponsorblock_skip_interaction: false,
+    sponsorblock_skip_intro: false,
+    sponsorblock_skip_outro: false,
+    sponsorblock_skip_preview: false,
+    sponsorblock_skip_hook: false,
+    sponsorblock_skip_filler: false,
     dearrow: false, //replaces titles and thumbnails with more accurate and less sensationalized versions from a crowdsourced database (https://dearrow.ajay.app/)
     dislikes: false, //readds youtube dislikes via https://www.returnyoutubedislike.com/
     remove_super_resolution: false, //block "super resolution" (ai upscaled qualities)

--- a/src/preload/modules/settings/index.js
+++ b/src/preload/modules/settings/index.js
@@ -80,7 +80,8 @@ const panelModules = [
     require('./panels/guide-tabs'),
     require('./panels/h264ify'),
     require('./panels/mac-permissions'),
-    require('./panels/userstyles')
+    require('./panels/userstyles'),
+    require('./panels/sponsorblock')
 ]
 
 const panels = {}

--- a/src/preload/modules/settings/panels/sponsorblock.js
+++ b/src/preload/modules/settings/panels/sponsorblock.js
@@ -1,0 +1,98 @@
+const { el, createToggle } = require('../dom')
+const scroll = require('../scroll')
+const configManager = require('../../../config')
+
+const viewport = scroll.bindViewport('sponsorblock')
+
+const SPONSORBLOCK_CATEGORIES = [ 'sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview', 'hook', 'filler' ]
+
+function getConfig() {
+    return configManager.get()
+}
+
+function updateInactiveState() {
+    const root = document.querySelector('.vt-content-panel[data-panel="sponsorblock"]')
+    if (!root) return;
+
+    const isEnabled = !!getConfig().sponsorblock
+
+    root.querySelectorAll('.vt-setting-item[data-sponsorblock="true"]').forEach((item) => {
+        item.classList.toggle('vt-setting-item-inactive', !isEnabled)
+        item.setAttribute('aria-disabled', isEnabled ? 'false' : 'true')
+    })
+}
+
+module.exports = {
+    id: 'sponsorblock',
+
+    init(ctx) {
+        locale = ctx.locale
+    },
+
+    render() {
+        const config = getConfig()
+
+        return el('div', { className: 'vt-sponsorblock-section' }, [
+            el('div', { className: 'vt-sponsorblock-viewport' }, [
+                el('div', { className: 'vt-sponsorblock-list', id: 'vt-sponsorblock-list' }, [
+                    el('div', {
+                        className: 'vt-setting-item',
+                        dataSetting: 'sponsorblock',
+                        dataIndex: '0'
+                    }, [
+                        el('div', { className: 'vt-setting-info' }, [
+                            el('span', { className: 'vt-setting-title', textContent: locale.settings.sponsorblock.title }),
+                            el('span', { className: 'vt-setting-description', textContent: locale.settings.sponsorblock.description })
+                        ]),
+                        el('div', { className: 'vt-setting-control' }, [
+                            createToggle('sponsorblock', config.sponsorblock)
+                        ])
+                    ]),
+
+                    ...SPONSORBLOCK_CATEGORIES.map((name, idx) => {
+                        const setting_name = `sponsorblock_skip_${name}`
+
+                          return el('div', {
+                            className: `vt-setting-item ${config.sponsorblock? '' : 'vt-setting-item-inactive'}`.trim(),
+                            dataSetting: setting_name,
+                            dataSponsorblock: 'true',
+                            dataIndex: String(idx + 1)
+                        }, [
+                            el('div', { className: 'vt-setting-info' }, [
+                                el('span', { className: 'vt-setting-title', textContent: locale.settings.sponsorblock.categories[name].name}),
+                                el('span', { className: 'vt-setting-description', textContent: locale.settings.sponsorblock.categories[name].description })
+                            ]),
+                            el('div', { className: 'vt-setting-control' }, [
+                                createToggle(setting_name, config[setting_name])
+                            ])
+                        ])
+                    })
+                ]),
+                el('div', { className: 'vt-scrollbar', id: 'vt-sponsorblock-scrollbar' }, [
+                    el('div', { className: 'vt-scrollbar-thumb', id: 'vt-sponsorblock-scrollbar-thumb' })
+                ])
+            ])
+        ])
+    },
+
+    setup() {
+        viewport.setup()
+    },
+
+    onShow() {
+        viewport.reset()
+        updateInactiveState()
+    },
+
+    onFocusItem(element) {
+        viewport.scrollTo(element)
+    },
+
+    onConfigUpdate(config) {
+        if (!config) return;
+
+        if (config.sponsorblock === undefined) return;
+
+        updateInactiveState()
+    }
+}

--- a/src/preload/modules/settings/style.css
+++ b/src/preload/modules/settings/style.css
@@ -342,6 +342,7 @@
     text-align: center;
 }
 
+.vt-sponsorblock-section,
 .vt-permissions-section,
 .vt-h264ify-section,
 .vt-guide-tabs-section {
@@ -352,6 +353,7 @@
     overflow: hidden;
 }
 
+.vt-sponsorblock-viewport,
 .vt-permissions-viewport,
 .vt-h264ify-viewport,
 .vt-guide-tabs-viewport {
@@ -361,6 +363,7 @@
     position: relative;
 }
 
+.vt-sponsorblock-list,
 .vt-permissions-list,
 .vt-h264ify-list,
 .vt-guide-tabs-list {
@@ -475,6 +478,7 @@
     transition: opacity 0.2s ease;
 }
 
+.vt-sponsorblock-viewport:hover .vt-scrollbar,
 .vt-userstyles-viewport:hover .vt-scrollbar,
 .vt-permissions-viewport:hover .vt-scrollbar,
 .vt-h264ify-viewport:hover .vt-scrollbar,

--- a/src/preload/modules/sponsorblock.js
+++ b/src/preload/modules/sponsorblock.js
@@ -4,6 +4,8 @@ const localeProvider = require('../util/localeProvider')
 const configManager = require('../config')
 const config = configManager.get()
 
+const SPONSORBLOCK_CATEGORIES = [ 'sponsor', 'selfpromo', 'interaction', 'intro', 'outro', 'preview', 'hook', 'filler' ]
+
 module.exports = async () => {
     await localeProvider.waitUntilAvailable()
     let locale = localeProvider.getLocale()
@@ -47,8 +49,7 @@ module.exports = async () => {
         console.log('[SponsorBlock] Skipping sponsor segment')
 
         activeVideo.currentTime = matchingSegment[0].endTime;
-
-        ui.toast('VacuumTube', locale.sponsorblock.sponsor_skipped)
+        ui.toast('VacuumTube', locale.sponsorblock[`${matchingSegment[0].category}_skipped`])
     }
 
     window.addEventListener('hashchange', () => {
@@ -60,7 +61,10 @@ module.exports = async () => {
             const videoId = pageUrl.searchParams.get('v')
 
             // TODO: Full SponsorBlock config so you can choose what categories to skip/show
-            const categories = ['sponsor']
+            const categories = SPONSORBLOCK_CATEGORIES.filter(
+                category => config[`sponsorblock_skip_${category}`]
+            )
+
             sponsorBlock.getSegments(videoId, categories).then((segments) => {
                 sponsorBlockSegments = segments;
                 activeVideoId = videoId;


### PR DESCRIPTION
Currently there is only an option to disable/enable sponsorblock. This commit allows users to choose which categories to enable/disable for sponsorblock from the settings UI.

sponsorblock has more advanced settings like selecting what kind of skip options to do like "auto skip", "show in seek bar", "manual skip", etc which are not addressed in this PR but this work will make it easier to do it in the future.

ref: https://github.com/shy1132/VacuumTube/issues/252